### PR TITLE
Added ResultEntityFactory + set java version to 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: trusty
 language: java
 jdk:
-  - oraclejdk11
+  - oraclejdk8
 script:
   - chmod -R ug+x .travis
   - .travis/build.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ def mavenCentralSignKeyId = "a1357827-1516-4fa2-ab8e-72cdea07a692"
 //// define and setjava version ////
 //// requires the java version to be set in the internal jenkins java version management
 //// use identifier accordingly
-def javaVersionId = 'jdk-11'
+def javaVersionId = 'jdk-8'
 
 //// set java version method (needs node{} for execution)
 def setJavaVersion(javaVersionId) {

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 
 ext {
 	//version (changing these should be considered thoroughly!)
-	javaVersion = JavaVersion.VERSION_11
+	javaVersion = JavaVersion.VERSION_1_8
 	unitsOfMeasurementVersion = '1.0.10'
 	tscfgVersion = '0.9.9'
 

--- a/src/main/java/edu/ie3/io/FileNamingStrategy.java
+++ b/src/main/java/edu/ie3/io/FileNamingStrategy.java
@@ -49,8 +49,8 @@ public class FileNamingStrategy {
    * @param suffix Suffixes of the files
    */
   public FileNamingStrategy(String prefix, String suffix) {
-    this.prefix = prefix.endsWith("_") || prefix.isBlank() ? prefix : prefix.concat("_");
-    this.suffix = suffix.startsWith("_") || prefix.isBlank() ? suffix : "_".concat(suffix);
+    this.prefix = prefix.endsWith("_") || prefix.isEmpty() ? prefix : prefix.concat("_");
+    this.suffix = suffix.startsWith("_") || prefix.isEmpty() ? suffix : "_".concat(suffix);
   }
 
   /**

--- a/src/main/java/edu/ie3/io/factory/SimpleEntityFactory.java
+++ b/src/main/java/edu/ie3/io/factory/SimpleEntityFactory.java
@@ -34,7 +34,7 @@ public abstract class SimpleEntityFactory<T extends UniqueEntity>
     final List<Set<String>> allFields = getFields(simpleEntityData);
 
     validateParameters(
-        simpleEntityData, allFields.toArray((IntFunction<Set<String>[]>) Set[]::new));
+        simpleEntityData, allFields.stream().toArray((IntFunction<Set<String>[]>) Set[]::new));
 
     try {
       // build the model

--- a/src/main/java/edu/ie3/io/factory/result/ConnectorResultFactory.java
+++ b/src/main/java/edu/ie3/io/factory/result/ConnectorResultFactory.java
@@ -7,7 +7,6 @@ package edu.ie3.io.factory.result;
 
 import edu.ie3.exceptions.FactoryException;
 import edu.ie3.io.factory.SimpleEntityData;
-import edu.ie3.io.factory.SimpleEntityFactory;
 import edu.ie3.models.StandardUnits;
 import edu.ie3.models.UniqueEntity;
 import edu.ie3.models.result.connector.*;
@@ -19,10 +18,8 @@ import javax.measure.quantity.Angle;
 import javax.measure.quantity.ElectricCurrent;
 import tec.uom.se.quantity.Quantities;
 
-public class ConnectorResultFactory extends SimpleEntityFactory<ConnectorResult> {
-  private static final String ENTITY_UUID = "uuid";
-  private static final String TIMESTAMP = "timestamp";
-  private static final String INPUT_MODEL = "inputModel";
+public class ConnectorResultFactory extends ResultEntityFactory<ConnectorResult> {
+
   private static final String IAMAG = "iamag";
   private static final String IAANG = "iaang";
   private static final String IBMAG = "ibmag";

--- a/src/main/java/edu/ie3/io/factory/result/NodeResultFactory.java
+++ b/src/main/java/edu/ie3/io/factory/result/NodeResultFactory.java
@@ -6,7 +6,6 @@
 package edu.ie3.io.factory.result;
 
 import edu.ie3.io.factory.SimpleEntityData;
-import edu.ie3.io.factory.SimpleEntityFactory;
 import edu.ie3.models.StandardUnits;
 import edu.ie3.models.result.NodeResult;
 import edu.ie3.util.TimeTools;
@@ -17,10 +16,7 @@ import javax.measure.quantity.Angle;
 import javax.measure.quantity.Dimensionless;
 import tec.uom.se.quantity.Quantities;
 
-public class NodeResultFactory extends SimpleEntityFactory<NodeResult> {
-  private static final String ENTITY_UUID = "uuid";
-  private static final String TIMESTAMP = "timestamp";
-  private static final String INPUT_MODEL = "inputModel";
+public class NodeResultFactory extends ResultEntityFactory<NodeResult> {
   private static final String VMAG = "vmag";
   private static final String VANG = "vang";
 

--- a/src/main/java/edu/ie3/io/factory/result/ResultEntityFactory.java
+++ b/src/main/java/edu/ie3/io/factory/result/ResultEntityFactory.java
@@ -1,0 +1,27 @@
+/*
+ * © 2020. TU Dortmund University,
+ * Institute of Energy Systems, Energy Efficiency and Energy Economics,
+ * Research group Distribution grid planning and operation
+*/
+package edu.ie3.io.factory.result;
+
+import edu.ie3.io.factory.SimpleEntityFactory;
+import edu.ie3.models.result.ResultEntity;
+
+/**
+ * Internal API for building {@link ResultEntity}s. This additional abstraction layer is necessary
+ * to create generic reader for {@link ResultEntity}s only and furthermore removes code duplicates.
+ *
+ * @version 0.1
+ * @since 11.02.20
+ */
+abstract class ResultEntityFactory<T extends ResultEntity> extends SimpleEntityFactory<T> {
+
+  protected static final String ENTITY_UUID = "uuid";
+  protected static final String TIMESTAMP = "timestamp";
+  protected static final String INPUT_MODEL = "inputModel";
+
+  public ResultEntityFactory(Class<? extends T>... allowedClasses) {
+    super(allowedClasses);
+  }
+}

--- a/src/main/java/edu/ie3/io/factory/result/SystemParticipantResultFactory.java
+++ b/src/main/java/edu/ie3/io/factory/result/SystemParticipantResultFactory.java
@@ -7,7 +7,6 @@ package edu.ie3.io.factory.result;
 
 import edu.ie3.exceptions.FactoryException;
 import edu.ie3.io.factory.SimpleEntityData;
-import edu.ie3.io.factory.SimpleEntityFactory;
 import edu.ie3.models.StandardUnits;
 import edu.ie3.models.UniqueEntity;
 import edu.ie3.models.result.system.*;
@@ -20,13 +19,11 @@ import javax.measure.quantity.Power;
 import tec.uom.se.quantity.Quantities;
 import tec.uom.se.unit.Units;
 
-public class SystemParticipantResultFactory extends SimpleEntityFactory<SystemParticipantResult> {
-  private static final String entityUuid = "uuid";
-  private static final String timestamp = "timestamp";
-  private static final String inputModel = "inputModel";
-  private static final String power = "p";
-  private static final String reactivePower = "q";
-  private static final String soc = "soc";
+public class SystemParticipantResultFactory extends ResultEntityFactory<SystemParticipantResult> {
+
+  private static final String POWER = "p";
+  private static final String REACTIVE_POWER = "q";
+  private static final String SOC = "soc";
 
   public SystemParticipantResultFactory() {
 
@@ -45,13 +42,13 @@ public class SystemParticipantResultFactory extends SimpleEntityFactory<SystemPa
   @Override
   protected List<Set<String>> getFields(SimpleEntityData simpleEntityData) {
     /// all result models have the same constructor except StorageResult
-    Set<String> minConstructorParams = newSet(timestamp, inputModel, power, reactivePower);
-    Set<String> optionalFields = expandSet(minConstructorParams, entityUuid);
+    Set<String> minConstructorParams = newSet(TIMESTAMP, INPUT_MODEL, POWER, REACTIVE_POWER);
+    Set<String> optionalFields = expandSet(minConstructorParams, ENTITY_UUID);
 
     if (simpleEntityData.getEntityClass().equals(StorageResult.class)
         || simpleEntityData.getEntityClass().equals(EvResult.class)) {
-      minConstructorParams = newSet(timestamp, inputModel, power, reactivePower, soc);
-      optionalFields = expandSet(minConstructorParams, entityUuid);
+      minConstructorParams = newSet(TIMESTAMP, INPUT_MODEL, POWER, REACTIVE_POWER, SOC);
+      optionalFields = expandSet(minConstructorParams, ENTITY_UUID);
     }
 
     return Arrays.asList(minConstructorParams, optionalFields);
@@ -62,18 +59,18 @@ public class SystemParticipantResultFactory extends SimpleEntityFactory<SystemPa
     Map<String, String> fieldsToValues = simpleEntityData.getFieldsToValues();
     Class<? extends UniqueEntity> clazz = simpleEntityData.getEntityClass();
 
-    ZonedDateTime zdtTimestamp = TimeTools.toZonedDateTime(fieldsToValues.get(timestamp));
-    UUID inputModelUuid = UUID.fromString(fieldsToValues.get(inputModel));
+    ZonedDateTime zdtTimestamp = TimeTools.toZonedDateTime(fieldsToValues.get(TIMESTAMP));
+    UUID inputModelUuid = UUID.fromString(fieldsToValues.get(INPUT_MODEL));
     Quantity<Power> p =
         Quantities.getQuantity(
-            Double.parseDouble(fieldsToValues.get(power)), StandardUnits.ACTIVE_POWER_RESULT);
+            Double.parseDouble(fieldsToValues.get(POWER)), StandardUnits.ACTIVE_POWER_RESULT);
     Quantity<Power> q =
         Quantities.getQuantity(
-            Double.parseDouble(fieldsToValues.get(reactivePower)),
+            Double.parseDouble(fieldsToValues.get(REACTIVE_POWER)),
             StandardUnits.REACTIVE_POWER_RESULT);
     Optional<UUID> uuidOpt =
-        fieldsToValues.containsKey(entityUuid)
-            ? Optional.of(UUID.fromString(fieldsToValues.get(entityUuid)))
+        fieldsToValues.containsKey(ENTITY_UUID)
+            ? Optional.of(UUID.fromString(fieldsToValues.get(ENTITY_UUID)))
             : Optional.empty();
 
     if (clazz.equals(LoadResult.class)) {
@@ -106,14 +103,14 @@ public class SystemParticipantResultFactory extends SimpleEntityFactory<SystemPa
           .orElseGet(() -> new WecResult(zdtTimestamp, inputModelUuid, p, q));
     } else if (clazz.equals(EvResult.class)) {
       Quantity<Dimensionless> quantSoc =
-          Quantities.getQuantity(Double.parseDouble(fieldsToValues.get(soc)), Units.PERCENT);
+          Quantities.getQuantity(Double.parseDouble(fieldsToValues.get(SOC)), Units.PERCENT);
 
       return uuidOpt
           .map(uuid -> new EvResult(uuid, zdtTimestamp, inputModelUuid, p, q, quantSoc))
           .orElseGet(() -> new EvResult(zdtTimestamp, inputModelUuid, p, q, quantSoc));
     } else if (clazz.equals(StorageResult.class)) {
       Quantity<Dimensionless> socQuantity =
-          Quantities.getQuantity(Double.parseDouble(fieldsToValues.get(soc)), Units.PERCENT);
+          Quantities.getQuantity(Double.parseDouble(fieldsToValues.get(SOC)), Units.PERCENT);
 
       return uuidOpt
           .map(uuid -> new StorageResult(uuid, zdtTimestamp, inputModelUuid, p, q, socQuantity))

--- a/src/main/java/edu/ie3/io/factory/result/ThermalSinkResultFactory.java
+++ b/src/main/java/edu/ie3/io/factory/result/ThermalSinkResultFactory.java
@@ -6,7 +6,6 @@
 package edu.ie3.io.factory.result;
 
 import edu.ie3.io.factory.SimpleEntityData;
-import edu.ie3.io.factory.SimpleEntityFactory;
 import edu.ie3.models.StandardUnits;
 import edu.ie3.models.result.ThermalSinkResult;
 import edu.ie3.util.TimeTools;
@@ -16,11 +15,9 @@ import javax.measure.Quantity;
 import javax.measure.quantity.Energy;
 import tec.uom.se.quantity.Quantities;
 
-public class ThermalSinkResultFactory extends SimpleEntityFactory<ThermalSinkResult> {
-  private static final String entityUuid = "uuid";
-  private static final String timestamp = "timestamp";
-  private static final String inputModel = "inputModel";
-  private static final String qDemand = "qDemand";
+public class ThermalSinkResultFactory extends ResultEntityFactory<ThermalSinkResult> {
+
+  private static final String Q_DEMAND = "qDemand";
 
   public ThermalSinkResultFactory() {
     super(ThermalSinkResult.class);
@@ -28,8 +25,8 @@ public class ThermalSinkResultFactory extends SimpleEntityFactory<ThermalSinkRes
 
   @Override
   protected List<Set<String>> getFields(SimpleEntityData simpleEntityData) {
-    Set<String> minConstructorParams = newSet(timestamp, inputModel, qDemand);
-    Set<String> optionalFields = expandSet(minConstructorParams, entityUuid);
+    Set<String> minConstructorParams = newSet(TIMESTAMP, INPUT_MODEL, Q_DEMAND);
+    Set<String> optionalFields = expandSet(minConstructorParams, ENTITY_UUID);
 
     return Arrays.asList(minConstructorParams, optionalFields);
   }
@@ -38,14 +35,14 @@ public class ThermalSinkResultFactory extends SimpleEntityFactory<ThermalSinkRes
   protected ThermalSinkResult buildModel(SimpleEntityData simpleEntityData) {
     Map<String, String> fieldsToValues = simpleEntityData.getFieldsToValues();
 
-    ZonedDateTime zdtTimestamp = TimeTools.toZonedDateTime(fieldsToValues.get(timestamp));
-    UUID inputModelUuid = UUID.fromString(fieldsToValues.get(inputModel));
+    ZonedDateTime zdtTimestamp = TimeTools.toZonedDateTime(fieldsToValues.get(TIMESTAMP));
+    UUID inputModelUuid = UUID.fromString(fieldsToValues.get(INPUT_MODEL));
     Quantity<Energy> qDemandQuantity =
         Quantities.getQuantity(
-            Double.parseDouble(fieldsToValues.get(qDemand)), StandardUnits.HEAT_DEMAND);
+            Double.parseDouble(fieldsToValues.get(Q_DEMAND)), StandardUnits.HEAT_DEMAND);
     Optional<UUID> uuidOpt =
-        fieldsToValues.containsKey(entityUuid)
-            ? Optional.of(UUID.fromString(fieldsToValues.get(entityUuid)))
+        fieldsToValues.containsKey(ENTITY_UUID)
+            ? Optional.of(UUID.fromString(fieldsToValues.get(ENTITY_UUID)))
             : Optional.empty();
 
     return uuidOpt

--- a/src/main/java/edu/ie3/models/OperationTime.java
+++ b/src/main/java/edu/ie3/models/OperationTime.java
@@ -80,7 +80,7 @@ public class OperationTime {
    */
   public boolean includes(ZonedDateTime date) {
     Optional<ClosedInterval<ZonedDateTime>> optOperationTime = getOperationLimit();
-    return optOperationTime.isEmpty() || optOperationTime.get().includes(date);
+    return !optOperationTime.isPresent() || optOperationTime.get().includes(date);
   }
 
   @Override

--- a/src/test/java/edu/ie3/models/OperationTimeTest.java
+++ b/src/test/java/edu/ie3/models/OperationTimeTest.java
@@ -45,8 +45,8 @@ class OperationTimeTest {
     OperationTime notLimited = OperationTime.notLimited();
     assertEquals(NOT_LIMITED_OPERATION, notLimited);
     assertFalse(notLimited.isLimited());
-    assertTrue(notLimited.getStartDate().isEmpty());
-    assertTrue(notLimited.getEndDate().isEmpty());
+    assertTrue(!notLimited.getStartDate().isPresent());
+    assertTrue(!notLimited.getEndDate().isPresent());
     assertEquals(Optional.empty(), notLimited.getOperationLimit());
   }
 
@@ -63,10 +63,10 @@ class OperationTimeTest {
     assertEquals(START_DATE, startDate);
 
     optStartDate = LIMITED_OPERATION_TIME_END_ONLY.getStartDate();
-    assertTrue(optStartDate.isEmpty());
+    assertTrue(!optStartDate.isPresent());
 
     optStartDate = NOT_LIMITED_OPERATION.getStartDate();
-    assertTrue(optStartDate.isEmpty());
+    assertTrue(!optStartDate.isPresent());
   }
 
   @Test
@@ -77,7 +77,7 @@ class OperationTimeTest {
     assertEquals(END_DATE, endDate);
 
     optEndDate = LIMITED_OPERATION_TIME_START_ONLY.getEndDate();
-    assertTrue(optEndDate.isEmpty());
+    assertTrue(!optEndDate.isPresent());
 
     optEndDate = LIMITED_OPERATION_TIME_END_ONLY.getEndDate();
     assertTrue(optEndDate.isPresent());
@@ -85,7 +85,7 @@ class OperationTimeTest {
     assertEquals(END_DATE, endDate);
 
     optEndDate = NOT_LIMITED_OPERATION.getEndDate();
-    assertTrue(optEndDate.isEmpty());
+    assertTrue(!optEndDate.isPresent());
   }
 
   @Test
@@ -107,7 +107,7 @@ class OperationTimeTest {
     assertEquals(new ClosedInterval<>(MIN_DATE, END_DATE), operationLimit);
 
     optOperationLimit = NOT_LIMITED_OPERATION.getOperationLimit();
-    assertTrue(optOperationLimit.isEmpty());
+    assertTrue(!optOperationLimit.isPresent());
   }
 
   @Test


### PR DESCRIPTION
This PR solves two (discussed but not written down issues):

- set java version back to 1.8 as we primarily use features that are available in java 8 as well (except a few ones) and hence to improve backward compatibility java 8 seems more suitable
- added a ResultEntityFactory as a new abstract class for all ResultEntityFactories implementation so allow the creation of generic ResultEntity readers as well as removing some code duplications