### PR TITLE
Missing default constructor in DistanceWeightedEdge

### DIFF
--- a/src/main/java/edu/ie3/datamodel/graph/DistanceWeightedEdge.java
+++ b/src/main/java/edu/ie3/datamodel/graph/DistanceWeightedEdge.java
@@ -27,6 +27,8 @@ public class DistanceWeightedEdge extends DefaultWeightedEdge {
 
   private double distance;
 
+  public DistanceWeightedEdge() {}
+
   public DistanceWeightedEdge(ComparableQuantity<Length> weightQuantity) {
     this.distance = weightQuantity.to(DEFAULT_UNIT).getValue().doubleValue();
   }


### PR DESCRIPTION
Missing default constructor in DistanceWeightedEdge<br>
<b>Issue/Task: </b><a href="https://github.com/ie3-institute/PowerSystemDataModel/issues/122" target="_blank">#122</a> <br>
<b>Progress: </b>100 %<br>
<b>Urgency: </b>High<br>