### PR TITLE
Remove invalid fields from SwitchResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ most of the commonly known power flow calculations
 coordinates or multiple exactly equal coordinates possible
 -  Extended functionality of `GridAndGeoUtils`
 - `CsvFileConnector` is now set up to process either UniqueEntities or only by file name
+- `SwitchResult` superclass changed from `ConnectorResult` to `ResultEntity`
 
 ### Fixed
 -  CsvDataSource now stops trying to get an operator for empty operator uuid field in entities

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ most of the commonly known power flow calculations
 -  Introduction of a ``IdCoordinateSource`` and implementation of  corresponding csv source for ID to coordinate mapping
 -  Factory for ``TimeBasedValues<WeatherValue>``
 -  Documentation with Sphinx / ReadTheDocs: [https://powersystemdatamodel.readthedocs.io/en/latest/](https://powersystemdatamodel.readthedocs.io/en/latest/)
+-  Introduction of``SwitchResultFactory`` to build adapted ``SwitchResult`` entities
 
 ### Changed
 -  Disabled concurrent writing in `CsvFileSink.persistJointGrid()` as this caused concurrency issues

--- a/docs/uml/main/OutputDatamodelConcept.puml
+++ b/docs/uml/main/OutputDatamodelConcept.puml
@@ -59,7 +59,7 @@ package models {
             class SwitchResult{
                 + closed: boolean
             }
-            ConnectorResult <|-- SwitchResult
+            ResultEntity <|-- SwitchResult
         }
 
         package system {

--- a/src/main/java/edu/ie3/datamodel/io/connectors/InfluxDbConnector.java
+++ b/src/main/java/edu/ie3/datamodel/io/connectors/InfluxDbConnector.java
@@ -98,7 +98,7 @@ public class InfluxDbConnector implements DataConnector {
   /**
    * Parses the result of an influxQL query for all measurements (e.g. weather)
    *
-   * @return a map of (measurement name -> Set of maps of (field name -> field value) for each
+   * @return a map of (measurement name to Set of maps of (field name to field value) for each
    *     result entity)
    */
   public static Map<String, Set<Map<String, String>>> parseQueryResult(QueryResult queryResult) {
@@ -109,7 +109,7 @@ public class InfluxDbConnector implements DataConnector {
    * Parses the result of one or multiple influxQL queries for the given measurements (e.g.
    * weather). If no measurement names are given, all results are parsed and returned
    *
-   * @return a map of (measurement name -> Set of maps of (field name -> field value) for each
+   * @return a map of (measurement name to Set of maps of (field name to field value) for each
    *     result entity)
    */
   public static Map<String, Set<Map<String, String>>> parseQueryResult(
@@ -137,7 +137,7 @@ public class InfluxDbConnector implements DataConnector {
    * Parses the result of one influxQL query for the given measurements (e.g. weather). If no
    * measurement names are given, all results are parsed and returned
    *
-   * @return a map of (measurement name -> Set of maps of (field name -> field value) for each
+   * @return a map of (measurement name to Set of maps of (field name to field value) for each
    *     result entity)
    */
   public static Map<String, Set<Map<String, String>>> parseResult(
@@ -154,7 +154,7 @@ public class InfluxDbConnector implements DataConnector {
   /**
    * Parses the results for a single measurement series
    *
-   * @return Set of maps of (field name -> field value) for each result entity
+   * @return Set of maps of (field name to field value) for each result entity
    */
   public static Set<Map<String, String>> parseSeries(QueryResult.Series series) {
     String[] columns = series.getColumns().toArray(new String[0]);
@@ -166,7 +166,7 @@ public class InfluxDbConnector implements DataConnector {
   /**
    * Parses a listt of values and maps them to field names using the given column name and order
    *
-   * @return Map of (field name -> field value) for one result entity
+   * @return Map of (field name to field value) for one result entity
    */
   public static Map<String, String> parseValueList(List<?> valueList, String[] columns) {
     Map<String, String> attributeMap = new HashMap<>();

--- a/src/main/java/edu/ie3/datamodel/io/factory/result/ConnectorResultFactory.java
+++ b/src/main/java/edu/ie3/datamodel/io/factory/result/ConnectorResultFactory.java
@@ -25,12 +25,11 @@ public class ConnectorResultFactory extends ResultEntityFactory<ConnectorResult>
   private static final String IBANG = "ibang";
   private static final String ICMAG = "icmag";
   private static final String ICANG = "icang";
-  private static final String CLOSED = "closed";
   private static final String TAPPOS = "tappos";
 
   public ConnectorResultFactory() {
     super(
-        LineResult.class, SwitchResult.class, Transformer2WResult.class, Transformer3WResult.class);
+        LineResult.class, Transformer2WResult.class, Transformer3WResult.class);
   }
 
   @Override
@@ -40,10 +39,7 @@ public class ConnectorResultFactory extends ResultEntityFactory<ConnectorResult>
     Set<String> optionalFields = expandSet(minConstructorParams, ENTITY_UUID);
 
     final Class<? extends UniqueEntity> entityClass = simpleEntityData.getEntityClass();
-    if (entityClass.equals(SwitchResult.class)) {
-      minConstructorParams = newSet(TIMESTAMP, INPUT_MODEL, IAMAG, IAANG, IBMAG, IBANG, CLOSED);
-      optionalFields = expandSet(minConstructorParams, ENTITY_UUID);
-    } else if (entityClass.equals(Transformer2WResult.class)) {
+     if (entityClass.equals(Transformer2WResult.class)) {
       minConstructorParams = newSet(TIMESTAMP, INPUT_MODEL, IAMAG, IAANG, IBMAG, IBANG, TAPPOS);
       optionalFields = expandSet(minConstructorParams, ENTITY_UUID);
     } else if (entityClass.equals(Transformer3WResult.class)) {
@@ -75,16 +71,7 @@ public class ConnectorResultFactory extends ResultEntityFactory<ConnectorResult>
       return uuidOpt
           .map(uuid -> new LineResult(uuid, timestamp, inputModel, iAMag, iAAng, iBMag, iBAng))
           .orElseGet(() -> new LineResult(timestamp, inputModel, iAMag, iAAng, iBMag, iBAng));
-    else if (entityClass.equals(SwitchResult.class)) {
-      final boolean closed = data.getBoolean(CLOSED);
-
-      return uuidOpt
-          .map(
-              uuid ->
-                  new SwitchResult(uuid, timestamp, inputModel, iAMag, iAAng, iBMag, iBAng, closed))
-          .orElseGet(
-              () -> new SwitchResult(timestamp, inputModel, iAMag, iAAng, iBMag, iBAng, closed));
-    } else if (entityClass.equals(Transformer2WResult.class)) {
+    else if (entityClass.equals(Transformer2WResult.class)) {
       final int tapPos = data.getInt(TAPPOS);
 
       return uuidOpt

--- a/src/main/java/edu/ie3/datamodel/io/factory/result/ConnectorResultFactory.java
+++ b/src/main/java/edu/ie3/datamodel/io/factory/result/ConnectorResultFactory.java
@@ -28,8 +28,7 @@ public class ConnectorResultFactory extends ResultEntityFactory<ConnectorResult>
   private static final String TAPPOS = "tappos";
 
   public ConnectorResultFactory() {
-    super(
-        LineResult.class, Transformer2WResult.class, Transformer3WResult.class);
+    super(LineResult.class, Transformer2WResult.class, Transformer3WResult.class);
   }
 
   @Override
@@ -39,7 +38,7 @@ public class ConnectorResultFactory extends ResultEntityFactory<ConnectorResult>
     Set<String> optionalFields = expandSet(minConstructorParams, ENTITY_UUID);
 
     final Class<? extends UniqueEntity> entityClass = simpleEntityData.getEntityClass();
-     if (entityClass.equals(Transformer2WResult.class)) {
+    if (entityClass.equals(Transformer2WResult.class)) {
       minConstructorParams = newSet(TIMESTAMP, INPUT_MODEL, IAMAG, IAANG, IBMAG, IBANG, TAPPOS);
       optionalFields = expandSet(minConstructorParams, ENTITY_UUID);
     } else if (entityClass.equals(Transformer3WResult.class)) {

--- a/src/main/java/edu/ie3/datamodel/io/factory/result/SwitchResultFactory.java
+++ b/src/main/java/edu/ie3/datamodel/io/factory/result/SwitchResultFactory.java
@@ -1,41 +1,44 @@
+/*
+ * © 2020. TU Dortmund University,
+ * Institute of Energy Systems, Energy Efficiency and Energy Economics,
+ * Research group Distribution grid planning and operation
+*/
 package edu.ie3.datamodel.io.factory.result;
 
 import edu.ie3.datamodel.io.factory.SimpleEntityData;
 import edu.ie3.datamodel.models.result.connector.SwitchResult;
 import edu.ie3.util.TimeUtil;
-
 import java.time.ZonedDateTime;
 import java.util.*;
 
-
 public class SwitchResultFactory extends ResultEntityFactory<SwitchResult> {
 
-    private static final String CLOSED = "closed";
+  private static final String CLOSED = "closed";
 
-    public SwitchResultFactory() {
-        super(SwitchResult.class);
-    }
+  public SwitchResultFactory() {
+    super(SwitchResult.class);
+  }
 
-    @Override
-    protected List<Set<String>> getFields(SimpleEntityData data) {
+  @Override
+  protected List<Set<String>> getFields(SimpleEntityData data) {
 
-        Set<String> minConstructorParams = newSet(TIMESTAMP, INPUT_MODEL, CLOSED);
-        Set<String> optionalFields = expandSet(minConstructorParams, ENTITY_UUID);
+    Set<String> minConstructorParams = newSet(TIMESTAMP, INPUT_MODEL, CLOSED);
+    Set<String> optionalFields = expandSet(minConstructorParams, ENTITY_UUID);
 
-        return Arrays.asList(minConstructorParams, optionalFields);
-    }
+    return Arrays.asList(minConstructorParams, optionalFields);
+  }
 
-    @Override
-    protected SwitchResult buildModel(SimpleEntityData data) {
-        Optional<UUID> uuidOpt =
-                        data.containsKey(ENTITY_UUID) ? Optional.of(data.getUUID(ENTITY_UUID)) : Optional.empty();
-        ZonedDateTime timestamp = TimeUtil.withDefaults.toZonedDateTime(data.getField(TIMESTAMP));
-        UUID inputModel = data.getUUID(INPUT_MODEL);
+  @Override
+  protected SwitchResult buildModel(SimpleEntityData data) {
+    Optional<UUID> uuidOpt =
+        data.containsKey(ENTITY_UUID) ? Optional.of(data.getUUID(ENTITY_UUID)) : Optional.empty();
+    ZonedDateTime timestamp = TimeUtil.withDefaults.toZonedDateTime(data.getField(TIMESTAMP));
+    UUID inputModel = data.getUUID(INPUT_MODEL);
 
-        final boolean closed = data.getBoolean(CLOSED);
+    final boolean closed = data.getBoolean(CLOSED);
 
-        return uuidOpt.map(uuid -> new SwitchResult(uuid, timestamp, inputModel, closed))
-                        .orElseGet(() -> new SwitchResult(timestamp, inputModel, closed));
-
-    }
+    return uuidOpt
+        .map(uuid -> new SwitchResult(uuid, timestamp, inputModel, closed))
+        .orElseGet(() -> new SwitchResult(timestamp, inputModel, closed));
+  }
 }

--- a/src/main/java/edu/ie3/datamodel/io/factory/result/SwitchResultFactory.java
+++ b/src/main/java/edu/ie3/datamodel/io/factory/result/SwitchResultFactory.java
@@ -1,0 +1,41 @@
+package edu.ie3.datamodel.io.factory.result;
+
+import edu.ie3.datamodel.io.factory.SimpleEntityData;
+import edu.ie3.datamodel.models.result.connector.SwitchResult;
+import edu.ie3.util.TimeUtil;
+
+import java.time.ZonedDateTime;
+import java.util.*;
+
+
+public class SwitchResultFactory extends ResultEntityFactory<SwitchResult> {
+
+    private static final String CLOSED = "closed";
+
+    public SwitchResultFactory() {
+        super(SwitchResult.class);
+    }
+
+    @Override
+    protected List<Set<String>> getFields(SimpleEntityData data) {
+
+        Set<String> minConstructorParams = newSet(TIMESTAMP, INPUT_MODEL, CLOSED);
+        Set<String> optionalFields = expandSet(minConstructorParams, ENTITY_UUID);
+
+        return Arrays.asList(minConstructorParams, optionalFields);
+    }
+
+    @Override
+    protected SwitchResult buildModel(SimpleEntityData data) {
+        Optional<UUID> uuidOpt =
+                        data.containsKey(ENTITY_UUID) ? Optional.of(data.getUUID(ENTITY_UUID)) : Optional.empty();
+        ZonedDateTime timestamp = TimeUtil.withDefaults.toZonedDateTime(data.getField(TIMESTAMP));
+        UUID inputModel = data.getUUID(INPUT_MODEL);
+
+        final boolean closed = data.getBoolean(CLOSED);
+
+        return uuidOpt.map(uuid -> new SwitchResult(uuid, timestamp, inputModel, closed))
+                        .orElseGet(() -> new SwitchResult(timestamp, inputModel, closed));
+
+    }
+}

--- a/src/main/java/edu/ie3/datamodel/io/factory/timeseries/TimeBasedWeatherValueData.java
+++ b/src/main/java/edu/ie3/datamodel/io/factory/timeseries/TimeBasedWeatherValueData.java
@@ -18,7 +18,7 @@ public class TimeBasedWeatherValueData extends EntityData {
   /**
    * Creates a new TimeBasedEntryData object
    *
-   * @param fieldsToAttributes attribute map: field name -> value
+   * @param fieldsToAttributes attribute map: field name to value
    * @param coordinate coordinate for this WeatherValue
    */
   public TimeBasedWeatherValueData(Map<String, String> fieldsToAttributes, Point coordinate) {

--- a/src/main/java/edu/ie3/datamodel/models/result/connector/SwitchResult.java
+++ b/src/main/java/edu/ie3/datamodel/models/result/connector/SwitchResult.java
@@ -5,17 +5,15 @@
 */
 package edu.ie3.datamodel.models.result.connector;
 
+import edu.ie3.datamodel.models.result.ResultEntity;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 import java.util.UUID;
-import javax.measure.quantity.Angle;
-import javax.measure.quantity.ElectricCurrent;
-import tec.uom.se.ComparableQuantity;
 
 /**
  * Represents calculation results of a {@link edu.ie3.datamodel.models.input.connector.SwitchInput}
  */
-public class SwitchResult extends ConnectorResult {
+public class SwitchResult extends ResultEntity {
 
   /** is the switching state 'closed'? */
   private boolean closed;
@@ -25,21 +23,10 @@ public class SwitchResult extends ConnectorResult {
    *
    * @param timestamp date and time when the result is produced
    * @param inputModel uuid of the input model that produces the result
-   * @param iAMag electric current magnitude @ port A, normally provided in Ampere
-   * @param iAAng electric current angle @ Port A in degree
-   * @param iBMag electric current magnitude @ port B, normally provided in Ampere
-   * @param iBAng electric current angle @ Port B in degree
    * @param closed true if switch is closed, false if switch is open
    */
-  public SwitchResult(
-      ZonedDateTime timestamp,
-      UUID inputModel,
-      ComparableQuantity<ElectricCurrent> iAMag,
-      ComparableQuantity<Angle> iAAng,
-      ComparableQuantity<ElectricCurrent> iBMag,
-      ComparableQuantity<Angle> iBAng,
-      boolean closed) {
-    super(timestamp, inputModel, iAMag, iAAng, iBMag, iBAng);
+  public SwitchResult(ZonedDateTime timestamp, UUID inputModel, boolean closed) {
+    super(timestamp, inputModel);
     this.closed = closed;
   }
 
@@ -50,22 +37,10 @@ public class SwitchResult extends ConnectorResult {
    *     above
    * @param timestamp date and time when the result is produced
    * @param inputModel uuid of the input model that produces the result
-   * @param iAMag electric current magnitude @ port A, normally provided in Ampere
-   * @param iAAng electric current angle @ Port A in degree
-   * @param iBMag electric current magnitude @ port B, normally provided in Ampere
-   * @param iBAng electric current angle @ Port B in degree
    * @param closed true if switch is closed, false if switch is open
    */
-  public SwitchResult(
-      UUID uuid,
-      ZonedDateTime timestamp,
-      UUID inputModel,
-      ComparableQuantity<ElectricCurrent> iAMag,
-      ComparableQuantity<Angle> iAAng,
-      ComparableQuantity<ElectricCurrent> iBMag,
-      ComparableQuantity<Angle> iBAng,
-      boolean closed) {
-    super(uuid, timestamp, inputModel, iAMag, iAAng, iBMag, iBAng);
+  public SwitchResult(UUID uuid, ZonedDateTime timestamp, UUID inputModel, boolean closed) {
+    super(uuid, timestamp, inputModel);
     this.closed = closed;
   }
 

--- a/src/main/java/edu/ie3/datamodel/models/result/system/EvcsResult.java
+++ b/src/main/java/edu/ie3/datamodel/models/result/system/EvcsResult.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 import javax.measure.quantity.Power;
 import tec.uom.se.ComparableQuantity;
 
-/** Represents calculation results of a {@link edu.ie3.datamodel.models.input.EvcsInput} */
+/** Represents calculation results of a {@link edu.ie3.datamodel.models.input.system.EvcsInput} */
 public class EvcsResult extends SystemParticipantResult {
   /**
    * Standard constructor with automatic uuid generation.

--- a/src/main/java/edu/ie3/datamodel/utils/ValidationUtils.java
+++ b/src/main/java/edu/ie3/datamodel/utils/ValidationUtils.java
@@ -320,13 +320,6 @@ public class ValidationUtils {
   public static void checkLineType(LineTypeInput lineType) {
     if (lineType == null)
       throw new NullPointerException("Expected a line type, but got nothing. :-(");
-    if (lineType.getvRated() == null
-        || lineType.getiMax() == null
-        || lineType.getB() == null
-        || lineType.getX() == null
-        || lineType.getR() == null
-        || lineType.getG() == null)
-      throw new InvalidEntityException("at least one value of line type is null", lineType);
 
     detectNegativeQuantities(new Quantity<?>[] {lineType.getB(), lineType.getG()}, lineType);
     detectZeroOrNegativeQuantities(

--- a/src/test/groovy/edu/ie3/datamodel/io/factory/result/ConnectorResultFactoryTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/factory/result/ConnectorResultFactoryTest.groovy
@@ -14,80 +14,71 @@ import spock.lang.Specification
 
 class ConnectorResultFactoryTest extends Specification implements FactoryTestHelper {
 
-	def "A ConnectorResultFactory should contain all expected classes for parsing"() {
-		given:
-		def resultFactory = new ConnectorResultFactory()
-		def expectedClasses = [
-			LineResult,
-			SwitchResult,
-			Transformer2WResult,
-			Transformer3WResult
-		]
+    def "A ConnectorResultFactory should contain all expected classes for parsing"() {
+        given:
+        def resultFactory = new ConnectorResultFactory()
+        def expectedClasses = [
+                LineResult,
+                Transformer2WResult,
+                Transformer3WResult
+        ]
 
-		expect:
-		resultFactory.classes() == Arrays.asList(expectedClasses.toArray())
-	}
+        expect:
+        resultFactory.classes() == Arrays.asList(expectedClasses.toArray())
+    }
 
-	def "A ConnectorResultFactory should parse a valid result model correctly"() {
-		given: "a system participant factory and model data"
-		def resultFactory = new ConnectorResultFactory()
-		Map<String, String> parameter = [
-			"timestamp":    "2020-01-30 17:26:44",
-			"inputModel":   "91ec3bcf-1777-4d38-af67-0bf7c9fa73c7",
-			"iamag":        "1.0",
-			"iaang":        "90",
-			"ibmag":        "0.98123",
-			"ibang":        "90"
-		]
+    def "A ConnectorResultFactory should parse a valid result model correctly"() {
+        given: "a connector result factory and model data"
+        def resultFactory = new ConnectorResultFactory()
+        Map<String, String> parameter = [
+                "timestamp" : "2020-01-30 17:26:44",
+                "inputModel": "91ec3bcf-1777-4d38-af67-0bf7c9fa73c7",
+                "iamag"     : "1.0",
+                "iaang"     : "90",
+                "ibmag"     : "0.98123",
+                "ibang"     : "90"
+        ]
 
-		if (modelClass == Transformer2WResult) {
-			parameter["tappos"] = "3"
-		}
-		if (modelClass == Transformer3WResult) {
-			parameter["tappos"] = "3"
-			parameter["icmag"] = "1.0"
-			parameter["icang"] = "90"
-		}
-		if (modelClass == SwitchResult) {
-			parameter["closed"] = "true"
-		}
+        if (modelClass == Transformer2WResult) {
+            parameter["tappos"] = "3"
+        }
+        if (modelClass == Transformer3WResult) {
+            parameter["tappos"] = "3"
+            parameter["icmag"] = "1.0"
+            parameter["icang"] = "90"
+        }
 
-		when:
-		Optional<? extends ConnectorResult> result = resultFactory.getEntity(new SimpleEntityData(parameter, modelClass))
+        when:
+        Optional<? extends ConnectorResult> result = resultFactory.getEntity(new SimpleEntityData(parameter, modelClass))
 
-		then:
-		result.present
-		result.get().getClass() == resultingModelClass
-		((ConnectorResult) result.get()).with {
-			assert timestamp == TimeTools.toZonedDateTime(parameter["timestamp"])
-			assert inputModel == UUID.fromString(parameter["inputModel"])
-			assert iAAng == getQuant(parameter["iaang"], StandardUnits.ELECTRIC_CURRENT_ANGLE)
-			assert iAMag == getQuant(parameter["iamag"], StandardUnits.ELECTRIC_CURRENT_MAGNITUDE)
-			assert iBAng == getQuant(parameter["ibang"], StandardUnits.ELECTRIC_CURRENT_ANGLE)
-			assert iBMag == getQuant(parameter["ibmag"], StandardUnits.ELECTRIC_CURRENT_MAGNITUDE)
-		}
+        then:
+        result.present
+        result.get().getClass() == resultingModelClass
+        ((ConnectorResult) result.get()).with {
+            assert timestamp == TimeTools.toZonedDateTime(parameter["timestamp"])
+            assert inputModel == UUID.fromString(parameter["inputModel"])
+            assert iAAng == getQuant(parameter["iaang"], StandardUnits.ELECTRIC_CURRENT_ANGLE)
+            assert iAMag == getQuant(parameter["iamag"], StandardUnits.ELECTRIC_CURRENT_MAGNITUDE)
+            assert iBAng == getQuant(parameter["ibang"], StandardUnits.ELECTRIC_CURRENT_ANGLE)
+            assert iBMag == getQuant(parameter["ibmag"], StandardUnits.ELECTRIC_CURRENT_MAGNITUDE)
+        }
 
-		if (result.get().getClass() == Transformer2WResult) {
-			assert ((Transformer2WResult) result.get()).tapPos == Integer.parseInt(parameter["tappos"])
-		}
+        if (result.get().getClass() == Transformer2WResult) {
+            assert ((Transformer2WResult) result.get()).tapPos == Integer.parseInt(parameter["tappos"])
+        }
 
-		if (result.get().getClass() == Transformer3WResult) {
-			Transformer3WResult transformer3WResult = ((Transformer3WResult) result.get())
-			assert transformer3WResult.tapPos == Integer.parseInt(parameter["tappos"])
-			assert transformer3WResult.iCAng == getQuant(parameter["icang"], StandardUnits.ELECTRIC_CURRENT_ANGLE)
-			assert transformer3WResult.iCMag == getQuant(parameter["icmag"], StandardUnits.ELECTRIC_CURRENT_MAGNITUDE)
-		}
-
-		if (result.get().getClass() == SwitchResult) {
-			assert ((SwitchResult) result.get()).closed == Boolean.parseBoolean(parameter["closed"])
-		}
+        if (result.get().getClass() == Transformer3WResult) {
+            Transformer3WResult transformer3WResult = ((Transformer3WResult) result.get())
+            assert transformer3WResult.tapPos == Integer.parseInt(parameter["tappos"])
+            assert transformer3WResult.iCAng == getQuant(parameter["icang"], StandardUnits.ELECTRIC_CURRENT_ANGLE)
+            assert transformer3WResult.iCMag == getQuant(parameter["icmag"], StandardUnits.ELECTRIC_CURRENT_MAGNITUDE)
+        }
 
 
-		where:
-		modelClass          || resultingModelClass
-		LineResult          || LineResult
-		SwitchResult        || SwitchResult
-		Transformer2WResult || Transformer2WResult
-		Transformer3WResult || Transformer3WResult
-	}
+        where:
+        modelClass          || resultingModelClass
+        LineResult          || LineResult
+        Transformer2WResult || Transformer2WResult
+        Transformer3WResult || Transformer3WResult
+    }
 }

--- a/src/test/groovy/edu/ie3/datamodel/io/factory/result/ConnectorResultFactoryTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/factory/result/ConnectorResultFactoryTest.groovy
@@ -14,71 +14,71 @@ import spock.lang.Specification
 
 class ConnectorResultFactoryTest extends Specification implements FactoryTestHelper {
 
-    def "A ConnectorResultFactory should contain all expected classes for parsing"() {
-        given:
-        def resultFactory = new ConnectorResultFactory()
-        def expectedClasses = [
-                LineResult,
-                Transformer2WResult,
-                Transformer3WResult
-        ]
+	def "A ConnectorResultFactory should contain all expected classes for parsing"() {
+		given:
+		def resultFactory = new ConnectorResultFactory()
+		def expectedClasses = [
+			LineResult,
+			Transformer2WResult,
+			Transformer3WResult
+		]
 
-        expect:
-        resultFactory.classes() == Arrays.asList(expectedClasses.toArray())
-    }
+		expect:
+		resultFactory.classes() == Arrays.asList(expectedClasses.toArray())
+	}
 
-    def "A ConnectorResultFactory should parse a valid result model correctly"() {
-        given: "a connector result factory and model data"
-        def resultFactory = new ConnectorResultFactory()
-        Map<String, String> parameter = [
-                "timestamp" : "2020-01-30 17:26:44",
-                "inputModel": "91ec3bcf-1777-4d38-af67-0bf7c9fa73c7",
-                "iamag"     : "1.0",
-                "iaang"     : "90",
-                "ibmag"     : "0.98123",
-                "ibang"     : "90"
-        ]
+	def "A ConnectorResultFactory should parse a valid result model correctly"() {
+		given: "a connector result factory and model data"
+		def resultFactory = new ConnectorResultFactory()
+		Map<String, String> parameter = [
+			"timestamp" : "2020-01-30 17:26:44",
+			"inputModel": "91ec3bcf-1777-4d38-af67-0bf7c9fa73c7",
+			"iamag"     : "1.0",
+			"iaang"     : "90",
+			"ibmag"     : "0.98123",
+			"ibang"     : "90"
+		]
 
-        if (modelClass == Transformer2WResult) {
-            parameter["tappos"] = "3"
-        }
-        if (modelClass == Transformer3WResult) {
-            parameter["tappos"] = "3"
-            parameter["icmag"] = "1.0"
-            parameter["icang"] = "90"
-        }
+		if (modelClass == Transformer2WResult) {
+			parameter["tappos"] = "3"
+		}
+		if (modelClass == Transformer3WResult) {
+			parameter["tappos"] = "3"
+			parameter["icmag"] = "1.0"
+			parameter["icang"] = "90"
+		}
 
-        when:
-        Optional<? extends ConnectorResult> result = resultFactory.getEntity(new SimpleEntityData(parameter, modelClass))
+		when:
+		Optional<? extends ConnectorResult> result = resultFactory.getEntity(new SimpleEntityData(parameter, modelClass))
 
-        then:
-        result.present
-        result.get().getClass() == resultingModelClass
-        ((ConnectorResult) result.get()).with {
-            assert timestamp == TimeTools.toZonedDateTime(parameter["timestamp"])
-            assert inputModel == UUID.fromString(parameter["inputModel"])
-            assert iAAng == getQuant(parameter["iaang"], StandardUnits.ELECTRIC_CURRENT_ANGLE)
-            assert iAMag == getQuant(parameter["iamag"], StandardUnits.ELECTRIC_CURRENT_MAGNITUDE)
-            assert iBAng == getQuant(parameter["ibang"], StandardUnits.ELECTRIC_CURRENT_ANGLE)
-            assert iBMag == getQuant(parameter["ibmag"], StandardUnits.ELECTRIC_CURRENT_MAGNITUDE)
-        }
+		then:
+		result.present
+		result.get().getClass() == resultingModelClass
+		((ConnectorResult) result.get()).with {
+			assert timestamp == TimeTools.toZonedDateTime(parameter["timestamp"])
+			assert inputModel == UUID.fromString(parameter["inputModel"])
+			assert iAAng == getQuant(parameter["iaang"], StandardUnits.ELECTRIC_CURRENT_ANGLE)
+			assert iAMag == getQuant(parameter["iamag"], StandardUnits.ELECTRIC_CURRENT_MAGNITUDE)
+			assert iBAng == getQuant(parameter["ibang"], StandardUnits.ELECTRIC_CURRENT_ANGLE)
+			assert iBMag == getQuant(parameter["ibmag"], StandardUnits.ELECTRIC_CURRENT_MAGNITUDE)
+		}
 
-        if (result.get().getClass() == Transformer2WResult) {
-            assert ((Transformer2WResult) result.get()).tapPos == Integer.parseInt(parameter["tappos"])
-        }
+		if (result.get().getClass() == Transformer2WResult) {
+			assert ((Transformer2WResult) result.get()).tapPos == Integer.parseInt(parameter["tappos"])
+		}
 
-        if (result.get().getClass() == Transformer3WResult) {
-            Transformer3WResult transformer3WResult = ((Transformer3WResult) result.get())
-            assert transformer3WResult.tapPos == Integer.parseInt(parameter["tappos"])
-            assert transformer3WResult.iCAng == getQuant(parameter["icang"], StandardUnits.ELECTRIC_CURRENT_ANGLE)
-            assert transformer3WResult.iCMag == getQuant(parameter["icmag"], StandardUnits.ELECTRIC_CURRENT_MAGNITUDE)
-        }
+		if (result.get().getClass() == Transformer3WResult) {
+			Transformer3WResult transformer3WResult = ((Transformer3WResult) result.get())
+			assert transformer3WResult.tapPos == Integer.parseInt(parameter["tappos"])
+			assert transformer3WResult.iCAng == getQuant(parameter["icang"], StandardUnits.ELECTRIC_CURRENT_ANGLE)
+			assert transformer3WResult.iCMag == getQuant(parameter["icmag"], StandardUnits.ELECTRIC_CURRENT_MAGNITUDE)
+		}
 
 
-        where:
-        modelClass          || resultingModelClass
-        LineResult          || LineResult
-        Transformer2WResult || Transformer2WResult
-        Transformer3WResult || Transformer3WResult
-    }
+		where:
+		modelClass          || resultingModelClass
+		LineResult          || LineResult
+		Transformer2WResult || Transformer2WResult
+		Transformer3WResult || Transformer3WResult
+	}
 }

--- a/src/test/groovy/edu/ie3/datamodel/io/factory/result/SwitchResultFactoryTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/factory/result/SwitchResultFactoryTest.groovy
@@ -1,0 +1,46 @@
+package edu.ie3.datamodel.io.factory.result
+
+import edu.ie3.datamodel.io.factory.SimpleEntityData
+import edu.ie3.datamodel.models.result.connector.SwitchResult
+import edu.ie3.test.helper.FactoryTestHelper
+import edu.ie3.util.TimeUtil
+import spock.lang.Specification
+
+
+class SwitchResultFactoryTest extends Specification implements FactoryTestHelper {
+
+
+    def "A SwitchResultFactory should contain all expected classes for parsing"() {
+        given:
+        def resultFactory = new SwitchResultFactory()
+        def expectedClasses = [
+                SwitchResult,
+        ]
+
+        expect:
+        resultFactory.classes() == Arrays.asList(expectedClasses.toArray())
+    }
+
+    def "A SwitchResultFactory should parse a valid result model correctly"() {
+        given: "a switch result factory and model data"
+        def resultFactory = new SwitchResultFactory()
+        Map<String, String> parameter = [
+                "timestamp" : "2020-01-30 17:26:44",
+                "inputModel": "91ec3bcf-1777-4d38-af67-0bf7c9fa73c7",
+                "closed"    : "true"
+        ]
+
+        when:
+        Optional<SwitchResult> result = resultFactory.getEntity(new SimpleEntityData(parameter, SwitchResult))
+
+        then:
+        result.present
+        result.get().getClass() == SwitchResult
+        ((SwitchResult) result.get()).with {
+            assert timestamp == TimeUtil.withDefaults.toZonedDateTime(parameter["timestamp"])
+            assert inputModel == UUID.fromString(parameter["inputModel"])
+            assert closed == Boolean.parseBoolean(parameter["closed"])
+        }
+    }
+
+}

--- a/src/test/groovy/edu/ie3/datamodel/io/factory/result/SwitchResultFactoryTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/factory/result/SwitchResultFactoryTest.groovy
@@ -1,3 +1,8 @@
+/*
+ * © 2020. TU Dortmund University,
+ * Institute of Energy Systems, Energy Efficiency and Energy Economics,
+ * Research group Distribution grid planning and operation
+ */
 package edu.ie3.datamodel.io.factory.result
 
 import edu.ie3.datamodel.io.factory.SimpleEntityData
@@ -10,37 +15,34 @@ import spock.lang.Specification
 class SwitchResultFactoryTest extends Specification implements FactoryTestHelper {
 
 
-    def "A SwitchResultFactory should contain all expected classes for parsing"() {
-        given:
-        def resultFactory = new SwitchResultFactory()
-        def expectedClasses = [
-                SwitchResult,
-        ]
+	def "A SwitchResultFactory should contain all expected classes for parsing"() {
+		given:
+		def resultFactory = new SwitchResultFactory()
+		def expectedClasses = [SwitchResult,]
 
-        expect:
-        resultFactory.classes() == Arrays.asList(expectedClasses.toArray())
-    }
+		expect:
+		resultFactory.classes() == Arrays.asList(expectedClasses.toArray())
+	}
 
-    def "A SwitchResultFactory should parse a valid result model correctly"() {
-        given: "a switch result factory and model data"
-        def resultFactory = new SwitchResultFactory()
-        Map<String, String> parameter = [
-                "timestamp" : "2020-01-30 17:26:44",
-                "inputModel": "91ec3bcf-1777-4d38-af67-0bf7c9fa73c7",
-                "closed"    : "true"
-        ]
+	def "A SwitchResultFactory should parse a valid result model correctly"() {
+		given: "a switch result factory and model data"
+		def resultFactory = new SwitchResultFactory()
+		Map<String, String> parameter = [
+			"timestamp" : "2020-01-30 17:26:44",
+			"inputModel": "91ec3bcf-1777-4d38-af67-0bf7c9fa73c7",
+			"closed"    : "true"
+		]
 
-        when:
-        Optional<SwitchResult> result = resultFactory.getEntity(new SimpleEntityData(parameter, SwitchResult))
+		when:
+		Optional<SwitchResult> result = resultFactory.getEntity(new SimpleEntityData(parameter, SwitchResult))
 
-        then:
-        result.present
-        result.get().getClass() == SwitchResult
-        ((SwitchResult) result.get()).with {
-            assert timestamp == TimeUtil.withDefaults.toZonedDateTime(parameter["timestamp"])
-            assert inputModel == UUID.fromString(parameter["inputModel"])
-            assert closed == Boolean.parseBoolean(parameter["closed"])
-        }
-    }
-
+		then:
+		result.present
+		result.get().getClass() == SwitchResult
+		((SwitchResult) result.get()).with {
+			assert timestamp == TimeUtil.withDefaults.toZonedDateTime(parameter["timestamp"])
+			assert inputModel == UUID.fromString(parameter["inputModel"])
+			assert closed == Boolean.parseBoolean(parameter["closed"])
+		}
+	}
 }

--- a/src/test/groovy/edu/ie3/datamodel/io/processor/result/ResultEntityProcessorTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/processor/result/ResultEntityProcessorTest.groovy
@@ -198,10 +198,6 @@ class ResultEntityProcessorTest extends Specification {
 	@Shared
 	def expectedSwitchResults = [uuid      : '22bea5fc-2cb2-4c61-beb9-b476e0107f52',
 		inputModel: '22bea5fc-2cb2-4c61-beb9-b476e0107f52',
-		iAMag     : '100.0',
-		iAAng     : '45.0',
-		iBMag     : '150.0',
-		iBAng     : '30.0',
 		closed    : 'true',
 		timestamp : '2020-01-30T17:26:44Z[UTC]']
 
@@ -241,7 +237,7 @@ class ResultEntityProcessorTest extends Specification {
 		where:
 		modelClass          | validConnectorResult                                                                                                                          || expectedResults
 		LineResult          | new LineResult(uuid, ZonedDateTime.parse("2020-01-30T17:26:44Z[UTC]"), inputModel, iAMag, iAAng, iBMag, iBAng)                                || expectedLineResults
-		SwitchResult        | new SwitchResult(uuid, ZonedDateTime.parse("2020-01-30T17:26:44Z[UTC]"), inputModel, iAMag, iAAng, iBMag, iBAng, closed)                      || expectedSwitchResults
+		SwitchResult        | new SwitchResult(uuid, ZonedDateTime.parse("2020-01-30T17:26:44Z[UTC]"), inputModel, closed)                    								|| expectedSwitchResults
 		Transformer2WResult | new Transformer2WResult(uuid, ZonedDateTime.parse("2020-01-30T17:26:44Z[UTC]"), inputModel, iAMag, iAAng, iBMag, iBAng, tapPos)               || expectedTrafo2WResults
 		Transformer3WResult | new Transformer3WResult(uuid, ZonedDateTime.parse("2020-01-30T17:26:44Z[UTC]"), inputModel, iAMag, iAAng, iBMag, iBAng, iCMag, iCAng, tapPos) || expectedTrafo3WResults
 	}

--- a/src/test/groovy/edu/ie3/datamodel/utils/ValidationUtilsTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/utils/ValidationUtilsTest.groovy
@@ -5,6 +5,9 @@
  */
 package edu.ie3.datamodel.utils
 
+import edu.ie3.datamodel.exceptions.InvalidEntityException
+import edu.ie3.datamodel.models.input.connector.type.LineTypeInput
+
 import static edu.ie3.util.quantities.PowerSystemUnits.PU
 import edu.ie3.datamodel.models.OperationTime
 import edu.ie3.datamodel.models.input.NodeInput
@@ -79,5 +82,22 @@ class ValidationUtilsTest extends Specification {
 			GridTestData.nodeD,
 			GridTestData.nodeE] as Set || Optional.empty()
 		[] as Set                          || Optional.empty()
+	}
+
+	def "The validation utils should thrown an null pointer exception if the provided type is null"() {
+		when:
+		ValidationUtils.checkLineType(null)
+
+		then:
+		NullPointerException ex = thrown()
+		ex.message == "Expected a line type, but got nothing. :-("
+	}
+
+	def "A LineType should throw a NullPointerException if the provided field values are null"() {
+		when:
+		new LineTypeInput(null, null, null,null,null,null,null,null)
+
+		then:
+		NullPointerException ex = thrown()
 	}
 }


### PR DESCRIPTION
Resolves #151 

I finally ended up just changing the superclass of `SwitchResult` to `ResultEntity` because introducing new interfaces or superclasses turned out to cause more harm than good. 

includes:
- new Factory for `SwitchResult` + corresponding tests 
- new test for `ValidationUtils`
- deleted unreachable code 