### PR TITLE
Added builder implementations to the required thermal input models

### DIFF
--- a/src/main/java/edu/ie3/datamodel/models/input/thermal/CylindricalStorageInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/thermal/CylindricalStorageInput.java
@@ -162,8 +162,7 @@ public class CylindricalStorageInput extends ThermalStorageInput {
    * CylindricalStorageInput}
    */
   public static class CylindricalStorageInputCopyBuilder
-      extends AssetInput.AssetInputCopyBuilder<
-          CylindricalStorageInput.CylindricalStorageInputCopyBuilder> {
+      extends AssetInput.AssetInputCopyBuilder<CylindricalStorageInputCopyBuilder> {
 
     private ComparableQuantity<Volume> storageVolumeLvl;
     private ComparableQuantity<Volume> storageVolumeLvlMin;
@@ -195,38 +194,36 @@ public class CylindricalStorageInput extends ThermalStorageInput {
           c);
     }
 
-    public CylindricalStorageInput.CylindricalStorageInputCopyBuilder storageVolumeLvl(
+    public CylindricalStorageInputCopyBuilder storageVolumeLvl(
         ComparableQuantity<Volume> storageVolumeLvl) {
       this.storageVolumeLvl = storageVolumeLvl;
       return this;
     }
 
-    public CylindricalStorageInput.CylindricalStorageInputCopyBuilder storageVolumeLvlMin(
+    public CylindricalStorageInputCopyBuilder storageVolumeLvlMin(
         ComparableQuantity<Volume> storageVolumeLvlMin) {
       this.storageVolumeLvlMin = storageVolumeLvlMin;
       return this;
     }
 
-    public CylindricalStorageInput.CylindricalStorageInputCopyBuilder inletTemp(
-        ComparableQuantity<Temperature> inletTemp) {
+    public CylindricalStorageInputCopyBuilder inletTemp(ComparableQuantity<Temperature> inletTemp) {
       this.inletTemp = inletTemp;
       return this;
     }
 
-    public CylindricalStorageInput.CylindricalStorageInputCopyBuilder returnTemp(
+    public CylindricalStorageInputCopyBuilder returnTemp(
         ComparableQuantity<Temperature> returnTemp) {
       this.returnTemp = returnTemp;
       return this;
     }
 
-    public CylindricalStorageInput.CylindricalStorageInputCopyBuilder c(
-        ComparableQuantity<SpecificHeatCapacity> c) {
+    public CylindricalStorageInputCopyBuilder c(ComparableQuantity<SpecificHeatCapacity> c) {
       this.c = c;
       return this;
     }
 
     @Override
-    protected CylindricalStorageInput.CylindricalStorageInputCopyBuilder childInstance() {
+    protected CylindricalStorageInputCopyBuilder childInstance() {
       return this;
     }
   }

--- a/src/main/java/edu/ie3/datamodel/models/input/thermal/CylindricalStorageInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/thermal/CylindricalStorageInput.java
@@ -7,7 +7,6 @@ package edu.ie3.datamodel.models.input.thermal;
 
 import edu.ie3.datamodel.models.OperationTime;
 import edu.ie3.datamodel.models.StandardUnits;
-import edu.ie3.datamodel.models.input.AssetInput;
 import edu.ie3.datamodel.models.input.OperatorInput;
 import edu.ie3.util.quantities.interfaces.SpecificHeatCapacity;
 import java.util.Objects;
@@ -161,8 +160,8 @@ public class CylindricalStorageInput extends ThermalStorageInput {
    * with altered field values. For detailed field descriptions refer to java docs of {@link
    * CylindricalStorageInput}
    */
-  public class CylindricalStorageInputCopyBuilder
-      extends AssetInput.AssetInputCopyBuilder<CylindricalStorageInputCopyBuilder> {
+  public static class CylindricalStorageInputCopyBuilder
+      extends ThermalUnitInput.ThermalUnitInputCopyBuilder<CylindricalStorageInputCopyBuilder> {
 
     private ComparableQuantity<Volume> storageVolumeLvl;
     private ComparableQuantity<Volume> storageVolumeLvlMin;

--- a/src/main/java/edu/ie3/datamodel/models/input/thermal/CylindricalStorageInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/thermal/CylindricalStorageInput.java
@@ -161,7 +161,7 @@ public class CylindricalStorageInput extends ThermalStorageInput {
    * with altered field values. For detailed field descriptions refer to java docs of {@link
    * CylindricalStorageInput}
    */
-  public static class CylindricalStorageInputCopyBuilder
+  public class CylindricalStorageInputCopyBuilder
       extends AssetInput.AssetInputCopyBuilder<CylindricalStorageInputCopyBuilder> {
 
     private ComparableQuantity<Volume> storageVolumeLvl;
@@ -186,7 +186,7 @@ public class CylindricalStorageInput extends ThermalStorageInput {
           getId(),
           getOperator(),
           getOperationTime(),
-          build().getThermalBus(),
+          getThermalBus(),
           storageVolumeLvl,
           storageVolumeLvlMin,
           inletTemp,

--- a/src/main/java/edu/ie3/datamodel/models/input/thermal/CylindricalStorageInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/thermal/CylindricalStorageInput.java
@@ -7,13 +7,13 @@ package edu.ie3.datamodel.models.input.thermal;
 
 import edu.ie3.datamodel.models.OperationTime;
 import edu.ie3.datamodel.models.StandardUnits;
+import edu.ie3.datamodel.models.input.AssetInput;
 import edu.ie3.datamodel.models.input.OperatorInput;
 import edu.ie3.util.quantities.interfaces.SpecificHeatCapacity;
 import java.util.Objects;
 import java.util.UUID;
 import javax.measure.quantity.Temperature;
 import javax.measure.quantity.Volume;
-import org.apache.commons.lang3.NotImplementedException;
 import tech.units.indriya.ComparableQuantity;
 
 /** Thermal storage with cylindrical shape */
@@ -107,10 +107,8 @@ public class CylindricalStorageInput extends ThermalStorageInput {
     return c;
   }
 
-  @Override
-  public UniqueEntityBuilder copy() {
-    throw new NotImplementedException(
-        "Copying of " + this.getClass().getSimpleName() + " entities is not supported yet!");
+  public CylindricalStorageInputCopyBuilder copy() {
+    return new CylindricalStorageInputCopyBuilder(this);
   }
 
   @Override
@@ -156,5 +154,80 @@ public class CylindricalStorageInput extends ThermalStorageInput {
         + ", c="
         + c
         + '}';
+  }
+
+  /**
+   * A builder pattern based approach to create copies of {@link CylindricalStorageInput} entities
+   * with altered field values. For detailed field descriptions refer to java docs of {@link
+   * CylindricalStorageInput}
+   */
+  public static class CylindricalStorageInputCopyBuilder
+      extends AssetInput.AssetInputCopyBuilder<
+          CylindricalStorageInput.CylindricalStorageInputCopyBuilder> {
+
+    private ComparableQuantity<Volume> storageVolumeLvl;
+    private ComparableQuantity<Volume> storageVolumeLvlMin;
+    private ComparableQuantity<Temperature> inletTemp;
+    private ComparableQuantity<Temperature> returnTemp;
+    private ComparableQuantity<SpecificHeatCapacity> c;
+
+    private CylindricalStorageInputCopyBuilder(CylindricalStorageInput entity) {
+      super(entity);
+      this.storageVolumeLvl = entity.getStorageVolumeLvl();
+      this.storageVolumeLvlMin = entity.getStorageVolumeLvlMin();
+      this.inletTemp = entity.getInletTemp();
+      this.returnTemp = entity.getReturnTemp();
+      this.c = entity.getC();
+    }
+
+    @Override
+    public CylindricalStorageInput build() {
+      return new CylindricalStorageInput(
+          getUuid(),
+          getId(),
+          getOperator(),
+          getOperationTime(),
+          build().getThermalBus(),
+          storageVolumeLvl,
+          storageVolumeLvlMin,
+          inletTemp,
+          returnTemp,
+          c);
+    }
+
+    public CylindricalStorageInput.CylindricalStorageInputCopyBuilder storageVolumeLvl(
+        ComparableQuantity<Volume> storageVolumeLvl) {
+      this.storageVolumeLvl = storageVolumeLvl;
+      return this;
+    }
+
+    public CylindricalStorageInput.CylindricalStorageInputCopyBuilder storageVolumeLvlMin(
+        ComparableQuantity<Volume> storageVolumeLvlMin) {
+      this.storageVolumeLvlMin = storageVolumeLvlMin;
+      return this;
+    }
+
+    public CylindricalStorageInput.CylindricalStorageInputCopyBuilder inletTemp(
+        ComparableQuantity<Temperature> inletTemp) {
+      this.inletTemp = inletTemp;
+      return this;
+    }
+
+    public CylindricalStorageInput.CylindricalStorageInputCopyBuilder returnTemp(
+        ComparableQuantity<Temperature> returnTemp) {
+      this.returnTemp = returnTemp;
+      return this;
+    }
+
+    public CylindricalStorageInput.CylindricalStorageInputCopyBuilder c(
+        ComparableQuantity<SpecificHeatCapacity> c) {
+      this.c = c;
+      return this;
+    }
+
+    @Override
+    protected CylindricalStorageInput.CylindricalStorageInputCopyBuilder childInstance() {
+      return this;
+    }
   }
 }

--- a/src/main/java/edu/ie3/datamodel/models/input/thermal/ThermalBusInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/thermal/ThermalBusInput.java
@@ -9,7 +9,6 @@ import edu.ie3.datamodel.models.OperationTime;
 import edu.ie3.datamodel.models.input.AssetInput;
 import edu.ie3.datamodel.models.input.OperatorInput;
 import java.util.UUID;
-import org.apache.commons.lang3.NotImplementedException;
 
 /** A thermal bus, to which different {@link ThermalUnitInput} units may be connected */
 public class ThermalBusInput extends AssetInput {
@@ -36,9 +35,30 @@ public class ThermalBusInput extends AssetInput {
     super(uuid, id);
   }
 
-  @Override
-  public UniqueEntityBuilder copy() {
-    throw new NotImplementedException(
-        "Copying of " + this.getClass().getSimpleName() + " entities is not supported yet!");
+  public ThermalBusInput.ThermalBusInputCopyBuilder copy() {
+    return new ThermalBusInput.ThermalBusInputCopyBuilder(this);
+  }
+
+  /**
+   * A builder pattern based approach to create copies of {@link ThermalBusInput} entities with
+   * altered field values. For detailed field descriptions refer to java docs of {@link
+   * ThermalBusInput}
+   */
+  public static class ThermalBusInputCopyBuilder
+      extends AssetInput.AssetInputCopyBuilder<ThermalBusInput.ThermalBusInputCopyBuilder> {
+
+    private ThermalBusInputCopyBuilder(ThermalBusInput entity) {
+      super(entity);
+    }
+
+    @Override
+    public ThermalBusInput build() {
+      return new ThermalBusInput(getUuid(), getId(), getOperator(), getOperationTime());
+    }
+
+    @Override
+    protected ThermalBusInput.ThermalBusInputCopyBuilder childInstance() {
+      return this;
+    }
   }
 }

--- a/src/main/java/edu/ie3/datamodel/models/input/thermal/ThermalBusInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/thermal/ThermalBusInput.java
@@ -44,7 +44,7 @@ public class ThermalBusInput extends AssetInput {
    * altered field values. For detailed field descriptions refer to java docs of {@link
    * ThermalBusInput}
    */
-  public static class ThermalBusInputCopyBuilder
+  public class ThermalBusInputCopyBuilder
       extends AssetInput.AssetInputCopyBuilder<ThermalBusInputCopyBuilder> {
 
     private ThermalBusInputCopyBuilder(ThermalBusInput entity) {

--- a/src/main/java/edu/ie3/datamodel/models/input/thermal/ThermalBusInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/thermal/ThermalBusInput.java
@@ -35,8 +35,8 @@ public class ThermalBusInput extends AssetInput {
     super(uuid, id);
   }
 
-  public ThermalBusInput.ThermalBusInputCopyBuilder copy() {
-    return new ThermalBusInput.ThermalBusInputCopyBuilder(this);
+  public ThermalBusInputCopyBuilder copy() {
+    return new ThermalBusInputCopyBuilder(this);
   }
 
   /**
@@ -45,7 +45,7 @@ public class ThermalBusInput extends AssetInput {
    * ThermalBusInput}
    */
   public static class ThermalBusInputCopyBuilder
-      extends AssetInput.AssetInputCopyBuilder<ThermalBusInput.ThermalBusInputCopyBuilder> {
+      extends AssetInput.AssetInputCopyBuilder<ThermalBusInputCopyBuilder> {
 
     private ThermalBusInputCopyBuilder(ThermalBusInput entity) {
       super(entity);
@@ -57,7 +57,7 @@ public class ThermalBusInput extends AssetInput {
     }
 
     @Override
-    protected ThermalBusInput.ThermalBusInputCopyBuilder childInstance() {
+    protected ThermalBusInputCopyBuilder childInstance() {
       return this;
     }
   }

--- a/src/main/java/edu/ie3/datamodel/models/input/thermal/ThermalBusInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/thermal/ThermalBusInput.java
@@ -44,7 +44,7 @@ public class ThermalBusInput extends AssetInput {
    * altered field values. For detailed field descriptions refer to java docs of {@link
    * ThermalBusInput}
    */
-  public class ThermalBusInputCopyBuilder
+  public static class ThermalBusInputCopyBuilder
       extends AssetInput.AssetInputCopyBuilder<ThermalBusInputCopyBuilder> {
 
     private ThermalBusInputCopyBuilder(ThermalBusInput entity) {

--- a/src/main/java/edu/ie3/datamodel/models/input/thermal/ThermalHouseInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/thermal/ThermalHouseInput.java
@@ -113,7 +113,7 @@ public class ThermalHouseInput extends ThermalSinkInput {
    * altered field values. For detailed field descriptions refer to java docs of {@link
    * ThermalHouseInput}
    */
-  public static class ThermalHouseInputCopyBuilder
+  public class ThermalHouseInputCopyBuilder
       extends AssetInput.AssetInputCopyBuilder<ThermalHouseInputCopyBuilder> {
 
     private ComparableQuantity<ThermalConductance> ethLosses;
@@ -132,7 +132,7 @@ public class ThermalHouseInput extends ThermalSinkInput {
           getId(),
           getOperator(),
           getOperationTime(),
-          build().getThermalBus(),
+          getThermalBus(),
           ethLosses,
           ethCapa);
     }

--- a/src/main/java/edu/ie3/datamodel/models/input/thermal/ThermalHouseInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/thermal/ThermalHouseInput.java
@@ -7,7 +7,6 @@ package edu.ie3.datamodel.models.input.thermal;
 
 import edu.ie3.datamodel.models.OperationTime;
 import edu.ie3.datamodel.models.StandardUnits;
-import edu.ie3.datamodel.models.input.AssetInput;
 import edu.ie3.datamodel.models.input.OperatorInput;
 import edu.ie3.util.quantities.interfaces.HeatCapacity;
 import edu.ie3.util.quantities.interfaces.ThermalConductance;
@@ -113,8 +112,8 @@ public class ThermalHouseInput extends ThermalSinkInput {
    * altered field values. For detailed field descriptions refer to java docs of {@link
    * ThermalHouseInput}
    */
-  public class ThermalHouseInputCopyBuilder
-      extends AssetInput.AssetInputCopyBuilder<ThermalHouseInputCopyBuilder> {
+  public static class ThermalHouseInputCopyBuilder
+      extends ThermalUnitInput.ThermalUnitInputCopyBuilder<ThermalHouseInputCopyBuilder> {
 
     private ComparableQuantity<ThermalConductance> ethLosses;
     private ComparableQuantity<HeatCapacity> ethCapa;

--- a/src/main/java/edu/ie3/datamodel/models/input/thermal/ThermalHouseInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/thermal/ThermalHouseInput.java
@@ -7,12 +7,12 @@ package edu.ie3.datamodel.models.input.thermal;
 
 import edu.ie3.datamodel.models.OperationTime;
 import edu.ie3.datamodel.models.StandardUnits;
+import edu.ie3.datamodel.models.input.AssetInput;
 import edu.ie3.datamodel.models.input.OperatorInput;
 import edu.ie3.util.quantities.interfaces.HeatCapacity;
 import edu.ie3.util.quantities.interfaces.ThermalConductance;
 import java.util.Objects;
 import java.util.UUID;
-import org.apache.commons.lang3.NotImplementedException;
 import tech.units.indriya.ComparableQuantity;
 
 /** Quite simple thermal model of a house to serve as a heat sink */
@@ -70,10 +70,8 @@ public class ThermalHouseInput extends ThermalSinkInput {
     return ethCapa;
   }
 
-  @Override
-  public UniqueEntityBuilder copy() {
-    throw new NotImplementedException(
-        "Copying of " + this.getClass().getSimpleName() + " entities is not supported yet!");
+  public ThermalHouseInput.ThermalHouseInputCopyBuilder copy() {
+    return new ThermalHouseInput.ThermalHouseInputCopyBuilder(this);
   }
 
   @Override
@@ -108,5 +106,52 @@ public class ThermalHouseInput extends ThermalSinkInput {
         + ", ethCapa="
         + ethCapa
         + '}';
+  }
+
+  /**
+   * A builder pattern based approach to create copies of {@link ThermalHouseInput} entities with
+   * altered field values. For detailed field descriptions refer to java docs of {@link
+   * ThermalHouseInput}
+   */
+  public static class ThermalHouseInputCopyBuilder
+      extends AssetInput.AssetInputCopyBuilder<ThermalHouseInput.ThermalHouseInputCopyBuilder> {
+
+    private ComparableQuantity<ThermalConductance> ethLosses;
+    private ComparableQuantity<HeatCapacity> ethCapa;
+
+    private ThermalHouseInputCopyBuilder(ThermalHouseInput entity) {
+      super(entity);
+      this.ethLosses = entity.getEthLosses();
+      this.ethCapa = entity.getEthCapa();
+    }
+
+    @Override
+    public ThermalHouseInput build() {
+      return new ThermalHouseInput(
+          getUuid(),
+          getId(),
+          getOperator(),
+          getOperationTime(),
+          build().getThermalBus(),
+          ethLosses,
+          ethCapa);
+    }
+
+    public ThermalHouseInput.ThermalHouseInputCopyBuilder ethLosses(
+        ComparableQuantity<ThermalConductance> ethLosses) {
+      this.ethLosses = ethLosses;
+      return this;
+    }
+
+    public ThermalHouseInput.ThermalHouseInputCopyBuilder ethCapa(
+        ComparableQuantity<HeatCapacity> ethCapa) {
+      this.ethCapa = ethCapa;
+      return this;
+    }
+
+    @Override
+    protected ThermalHouseInput.ThermalHouseInputCopyBuilder childInstance() {
+      return this;
+    }
   }
 }

--- a/src/main/java/edu/ie3/datamodel/models/input/thermal/ThermalHouseInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/thermal/ThermalHouseInput.java
@@ -70,8 +70,8 @@ public class ThermalHouseInput extends ThermalSinkInput {
     return ethCapa;
   }
 
-  public ThermalHouseInput.ThermalHouseInputCopyBuilder copy() {
-    return new ThermalHouseInput.ThermalHouseInputCopyBuilder(this);
+  public ThermalHouseInputCopyBuilder copy() {
+    return new ThermalHouseInputCopyBuilder(this);
   }
 
   @Override
@@ -114,7 +114,7 @@ public class ThermalHouseInput extends ThermalSinkInput {
    * ThermalHouseInput}
    */
   public static class ThermalHouseInputCopyBuilder
-      extends AssetInput.AssetInputCopyBuilder<ThermalHouseInput.ThermalHouseInputCopyBuilder> {
+      extends AssetInput.AssetInputCopyBuilder<ThermalHouseInputCopyBuilder> {
 
     private ComparableQuantity<ThermalConductance> ethLosses;
     private ComparableQuantity<HeatCapacity> ethCapa;
@@ -137,20 +137,19 @@ public class ThermalHouseInput extends ThermalSinkInput {
           ethCapa);
     }
 
-    public ThermalHouseInput.ThermalHouseInputCopyBuilder ethLosses(
+    public ThermalHouseInputCopyBuilder ethLosses(
         ComparableQuantity<ThermalConductance> ethLosses) {
       this.ethLosses = ethLosses;
       return this;
     }
 
-    public ThermalHouseInput.ThermalHouseInputCopyBuilder ethCapa(
-        ComparableQuantity<HeatCapacity> ethCapa) {
+    public ThermalHouseInputCopyBuilder ethCapa(ComparableQuantity<HeatCapacity> ethCapa) {
       this.ethCapa = ethCapa;
       return this;
     }
 
     @Override
-    protected ThermalHouseInput.ThermalHouseInputCopyBuilder childInstance() {
+    protected ThermalHouseInputCopyBuilder childInstance() {
       return this;
     }
   }

--- a/src/main/java/edu/ie3/datamodel/models/input/thermal/ThermalUnitInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/thermal/ThermalUnitInput.java
@@ -78,4 +78,35 @@ public abstract class ThermalUnitInput extends AssetInput implements HasThermalB
         + thermalBus.getUuid()
         + '}';
   }
+
+  /**
+   * Abstract class for all builders that build child entities of abstract class {@link
+   * ThermalUnitInput}
+   */
+  protected abstract static class ThermalUnitInputCopyBuilder<
+          T extends ThermalUnitInput.ThermalUnitInputCopyBuilder<T>>
+      extends AssetInputCopyBuilder<T> {
+
+    private ThermalBusInput thermalBus;
+
+    protected ThermalUnitInputCopyBuilder(ThermalUnitInput entity) {
+      super(entity);
+      this.thermalBus = entity.getThermalBus();
+    }
+
+    public T thermalBus(ThermalBusInput thermalBus) {
+      this.thermalBus = thermalBus;
+      return childInstance();
+    }
+
+    protected ThermalBusInput getThermalBus() {
+      return thermalBus;
+    }
+
+    @Override
+    public abstract ThermalUnitInput build();
+
+    @Override
+    protected abstract T childInstance();
+  }
 }

--- a/src/test/groovy/edu/ie3/datamodel/models/input/thermal/CylindricalStorageInputTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/input/thermal/CylindricalStorageInputTest.groovy
@@ -1,0 +1,38 @@
+/*
+ * © 2021. TU Dortmund University,
+ * Institute of Energy Systems, Energy Efficiency and Energy Economics,
+ * Research group Distribution grid planning and operation
+ */
+package edu.ie3.datamodel.models.input.thermal
+
+import edu.ie3.test.common.ThermalUnitInputTestData
+import spock.lang.Specification
+
+
+class CylindricalStorageInputTest extends Specification {
+
+	def "A CylindricalStorageInput copy method should work as expected"() {
+		given:
+		def cylindricalStorageInput = ThermalUnitInputTestData.cylindricStorageInput
+
+		when:
+		def alteredUnit = cylindricalStorageInput.copy().storageVolumeLvl(ThermalUnitInputTestData.storageVolumeLvl)
+				.storageVolumeLvlMin(ThermalUnitInputTestData.storageVolumeLvlMin).inletTemp(ThermalUnitInputTestData.inletTemp)
+				.returnTemp(ThermalUnitInputTestData.returnTemp).c(ThermalUnitInputTestData.c).build()
+
+
+		then:
+		alteredUnit.with {
+			assert uuid == cylindricalStorageInput.uuid
+			assert id == cylindricalStorageInput.id
+			assert operator == cylindricalStorageInput.operator
+			assert operationTime == cylindricalStorageInput.operationTime
+			assert thermalBus == cylindricalStorageInput.thermalBus
+			assert storageVolumeLvl == ThermalUnitInputTestData.storageVolumeLvl
+			assert storageVolumeLvlMin == ThermalUnitInputTestData.storageVolumeLvlMin
+			assert inletTemp == ThermalUnitInputTestData.inletTemp
+			assert returnTemp == ThermalUnitInputTestData.returnTemp
+			assert c == ThermalUnitInputTestData.c
+		}
+	}
+}

--- a/src/test/groovy/edu/ie3/datamodel/models/input/thermal/CylindricalStorageInputTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/input/thermal/CylindricalStorageInputTest.groovy
@@ -18,7 +18,8 @@ class CylindricalStorageInputTest extends Specification {
 		when:
 		def alteredUnit = cylindricalStorageInput.copy().storageVolumeLvl(ThermalUnitInputTestData.storageVolumeLvl)
 				.storageVolumeLvlMin(ThermalUnitInputTestData.storageVolumeLvlMin).inletTemp(ThermalUnitInputTestData.inletTemp)
-				.returnTemp(ThermalUnitInputTestData.returnTemp).c(ThermalUnitInputTestData.c).build()
+				.returnTemp(ThermalUnitInputTestData.returnTemp).c(ThermalUnitInputTestData.c)
+				.thermalBus(ThermalUnitInputTestData.thermalBus).build()
 
 
 		then:

--- a/src/test/groovy/edu/ie3/datamodel/models/input/thermal/ThermalBusInputTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/input/thermal/ThermalBusInputTest.groovy
@@ -1,0 +1,30 @@
+/*
+ * © 2021. TU Dortmund University,
+ * Institute of Energy Systems, Energy Efficiency and Energy Economics,
+ * Research group Distribution grid planning and operation
+ */
+package edu.ie3.datamodel.models.input.thermal
+
+import edu.ie3.test.common.ThermalUnitInputTestData
+import spock.lang.Specification
+
+
+class ThermalBusInputTest extends Specification {
+
+	def "A ThermalBusInput copy method should work as expected"() {
+		given:
+		def thermalBusInput = ThermalUnitInputTestData.thermalBus
+
+		when:
+		def alteredUnit = thermalBusInput.copy().build()
+
+
+		then:
+		alteredUnit.with {
+			assert uuid == thermalBusInput.uuid
+			assert id == thermalBusInput.id
+			assert operator == thermalBusInput.operator
+			assert operationTime == thermalBusInput.operationTime
+		}
+	}
+}

--- a/src/test/groovy/edu/ie3/datamodel/models/input/thermal/ThermalHouseInputTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/input/thermal/ThermalHouseInputTest.groovy
@@ -17,7 +17,7 @@ class ThermalHouseInputTest extends Specification {
 
 		when:
 		def alteredUnit = thermalHouseInput.copy().ethLosses(ThermalUnitInputTestData.thermalConductance)
-				.ethCapa(ThermalUnitInputTestData.ethCapa).build()
+				.ethCapa(ThermalUnitInputTestData.ethCapa).thermalBus(ThermalUnitInputTestData.thermalBus).build()
 
 
 		then:

--- a/src/test/groovy/edu/ie3/datamodel/models/input/thermal/ThermalHouseInputTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/input/thermal/ThermalHouseInputTest.groovy
@@ -1,0 +1,34 @@
+/*
+ * © 2021. TU Dortmund University,
+ * Institute of Energy Systems, Energy Efficiency and Energy Economics,
+ * Research group Distribution grid planning and operation
+ */
+package edu.ie3.datamodel.models.input.thermal
+
+import edu.ie3.test.common.ThermalUnitInputTestData
+import spock.lang.Specification
+
+
+class ThermalHouseInputTest extends Specification {
+
+	def "A ThermalHouseInput copy method should work as expected"() {
+		given:
+		def thermalHouseInput = ThermalUnitInputTestData.thermalHouseInput
+
+		when:
+		def alteredUnit = thermalHouseInput.copy().ethLosses(ThermalUnitInputTestData.thermalConductance)
+				.ethCapa(ThermalUnitInputTestData.ethCapa).build()
+
+
+		then:
+		alteredUnit.with {
+			assert uuid == thermalHouseInput.uuid
+			assert id == thermalHouseInput.id
+			assert operator == thermalHouseInput.operator
+			assert operationTime == thermalHouseInput.operationTime
+			assert thermalBus == thermalHouseInput.thermalBus
+			assert ethLosses == ThermalUnitInputTestData.thermalConductance
+			assert ethCapa == ThermalUnitInputTestData.ethCapa
+		}
+	}
+}


### PR DESCRIPTION
Resolves #165. Changes done -

1. Added `CylindricalStorageInputCopyBuilder`, `ThermalBusInputCopyBuilder` and `ThermalHouseInputCopyBuilder` to classes `CylindricalStorageInput`, `ThermalBusInput` and `ThermalHouseInput` respectively.

Next, I will work on test cases and code refinement.