### PR TITLE
Fix InfluxDB image version to latest working version

### DIFF
--- a/src/test/groovy/edu/ie3/datamodel/io/sink/InfluxDbSinkIT.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/sink/InfluxDbSinkIT.groovy
@@ -34,7 +34,7 @@ import java.time.ZonedDateTime
 class InfluxDbSinkIT extends Specification {
 
 	@Shared
-	InfluxDBContainer influxDbContainer = new InfluxDBContainer("latest")
+	InfluxDBContainer influxDbContainer = new InfluxDBContainer("1.8.4")
 	.withAuthEnabled(false)
 	.withDatabase("test_out")
 	.withExposedPorts(8086) as InfluxDBContainer

--- a/src/test/groovy/edu/ie3/datamodel/io/source/influxdb/InfluxDbWeatherSourcePsdmIT.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/source/influxdb/InfluxDbWeatherSourcePsdmIT.groovy
@@ -25,7 +25,7 @@ import spock.lang.Specification
 class InfluxDbWeatherSourcePsdmIT extends Specification implements WeatherSourceTestHelper {
 
 	@Shared
-	InfluxDBContainer influxDbContainer = new InfluxDBContainer("latest")
+	InfluxDBContainer influxDbContainer = new InfluxDBContainer("1.8.4")
 	.withAuthEnabled(false)
 	.withDatabase("test_weather")
 


### PR DESCRIPTION
Tests with InfluxDB testcontainers referenced the latest image version on dockerhub. However, somehow something has changed, why our tests started to fail.