### PR TITLE
Added a null check on the operators collection

### DIFF
--- a/src/main/java/edu/ie3/datamodel/io/source/csv/CsvDataSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/csv/CsvDataSource.java
@@ -329,6 +329,7 @@ public abstract class CsvDataSource {
    */
   protected <T extends UniqueEntity> Optional<T> findFirstEntityByUuid(
       String entityUuid, Collection<T> entities) {
+    if (entities == null) return Optional.empty();
     return entities.stream()
         .parallel()
         .filter(uniqueEntity -> uniqueEntity.getUuid().toString().equalsIgnoreCase(entityUuid))

--- a/src/test/groovy/edu/ie3/datamodel/io/source/csv/CsvDataSourceTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/source/csv/CsvDataSourceTest.groovy
@@ -66,6 +66,36 @@ class CsvDataSourceTest extends Specification {
 
 	DummyCsvSource dummyCsvSource = new DummyCsvSource(csvSep, testBaseFolderPath, fileNamingStrategy)
 
+	def "A csv data source returns empty optional, when looking for a specific uuid"() {
+		given:
+		def entities = null
+		def uuid = UUID.randomUUID().toString()
+
+		when:
+		def actual = dummyCsvSource.findFirstEntityByUuid(uuid, entities)
+
+		then:
+		!actual.present
+	}
+
+	def "A csv data source is able to find the correct first entity by uuid"() {
+		given:
+		def uuid = UUID.randomUUID()
+		def queriedOperator = new OperatorInput(uuid, "b")
+		def entities = Arrays.asList(
+				new OperatorInput(UUID.randomUUID(), "a"),
+				queriedOperator,
+				new OperatorInput(UUID.randomUUID(), "c")
+				)
+
+		when:
+		def actual = dummyCsvSource.findFirstEntityByUuid(uuid.toString(), entities)
+
+		then:
+		actual.present
+		actual.get() == queriedOperator
+	}
+
 	def "A DataSource should contain a valid connector after initialization"() {
 		expect:
 		dummyCsvSource.connector != null


### PR DESCRIPTION
Resolves #264. Changes done:
- Added a null check on the `operators` Collection. If the Collection is `null`, `OperatorInput.NO_OPERATOR_ASSIGNED` will be returned by the `getFirstOrDefaultOperator()` function.