### PR TITLE
Introducing SqlIndividualTimeSeriesMetaInformation & refactorings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - SQL time series sources (`SqlTimeSeriesSource` and `SqlTimeSeriesMappingSource`) [#467](https://github.com/ie3-institute/PowerSystemDataModel/issues/467)
 - Graph with impedance weighted edges including facilities to create it [#440](https://github.com/ie3-institute/PowerSystemDataModel/issues/440)
+- Introducing SqlIndividualTimeSeriesMetaInformation which also provides sql table names [#513](https://github.com/ie3-institute/PowerSystemDataModel/issues/513)
 
 ### Fixed
 - Reduced code smells [#492](https://github.com/ie3-institute/PowerSystemDataModel/issues/492)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - SQL time series sources (`SqlTimeSeriesSource` and `SqlTimeSeriesMappingSource`) [#467](https://github.com/ie3-institute/PowerSystemDataModel/issues/467)
 - Graph with impedance weighted edges including facilities to create it [#440](https://github.com/ie3-institute/PowerSystemDataModel/issues/440)
-- Introducing SqlIndividualTimeSeriesMetaInformation which also provides sql table names [#513](https://github.com/ie3-institute/PowerSystemDataModel/issues/513)
-
+- Introducing `SqlIndividualTimeSeriesMetaInformation` which provides sql table names [#513](https://github.com/ie3-institute/PowerSystemDataModel/issues/513)
 ### Fixed
 - Reduced code smells [#492](https://github.com/ie3-institute/PowerSystemDataModel/issues/492)
     - Protected constructors for abstract classes

--- a/src/main/java/edu/ie3/datamodel/io/connectors/CsvFileConnector.java
+++ b/src/main/java/edu/ie3/datamodel/io/connectors/CsvFileConnector.java
@@ -8,9 +8,10 @@ package edu.ie3.datamodel.io.connectors;
 import edu.ie3.datamodel.exceptions.ConnectorException;
 import edu.ie3.datamodel.io.IoUtil;
 import edu.ie3.datamodel.io.csv.*;
-import edu.ie3.datamodel.io.csv.timeseries.ColumnScheme;
-import edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation;
+import edu.ie3.datamodel.io.naming.DataSourceMetaInformation;
 import edu.ie3.datamodel.io.naming.FileNamingStrategy;
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme;
+import edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation;
 import edu.ie3.datamodel.models.UniqueEntity;
 import edu.ie3.datamodel.models.timeseries.TimeSeries;
 import edu.ie3.datamodel.models.timeseries.TimeSeriesEntry;
@@ -246,7 +247,7 @@ public class CsvFileConnector implements DataConnector {
               return new CsvIndividualTimeSeriesMetaInformation(
                   metaInformation, filePathWithoutEnding);
             })
-        .collect(Collectors.toMap(FileNameMetaInformation::getUuid, v -> v));
+        .collect(Collectors.toMap(DataSourceMetaInformation::getUuid, v -> v));
   }
 
   /**
@@ -325,7 +326,7 @@ public class CsvFileConnector implements DataConnector {
   private Optional<CsvIndividualTimeSeriesMetaInformation> buildCsvTimeSeriesMetaInformation(
       String filePathString, ColumnScheme... columnSchemes) {
     try {
-      FileNameMetaInformation metaInformation =
+      DataSourceMetaInformation metaInformation =
           fileNamingStrategy.extractTimeSeriesMetaInformation(filePathString);
       if (!IndividualTimeSeriesMetaInformation.class.isAssignableFrom(metaInformation.getClass())) {
         log.error(
@@ -456,9 +457,8 @@ public class CsvFileConnector implements DataConnector {
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (!(o instanceof CsvIndividualTimeSeriesMetaInformation)) return false;
+      if (!(o instanceof CsvIndividualTimeSeriesMetaInformation that)) return false;
       if (!super.equals(o)) return false;
-      CsvIndividualTimeSeriesMetaInformation that = (CsvIndividualTimeSeriesMetaInformation) o;
       return fullFilePath.equals(that.fullFilePath);
     }
 

--- a/src/main/java/edu/ie3/datamodel/io/connectors/SqlConnector.java
+++ b/src/main/java/edu/ie3/datamodel/io/connectors/SqlConnector.java
@@ -5,6 +5,8 @@
 */
 package edu.ie3.datamodel.io.connectors;
 
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme;
+import edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation;
 import edu.ie3.util.StringUtils;
 import edu.ie3.util.TimeUtil;
 import java.sql.*;
@@ -155,5 +157,52 @@ public class SqlConnector implements DataConnector {
       log.error("Exception at extracting ResultSet: ", e);
     }
     return insensitiveFieldsToAttributes;
+  }
+
+  /** Enhancing the {@link IndividualTimeSeriesMetaInformation} with the full path to csv file */
+  public static class SqlIndividualTimeSeriesMetaInformation
+      extends IndividualTimeSeriesMetaInformation {
+    private final String tableName;
+
+    public SqlIndividualTimeSeriesMetaInformation(
+        UUID uuid, ColumnScheme columnScheme, String tableName) {
+      super(uuid, columnScheme);
+      this.tableName = tableName;
+    }
+
+    public SqlIndividualTimeSeriesMetaInformation(
+        IndividualTimeSeriesMetaInformation metaInformation, String fullFilePath) {
+      this(metaInformation.getUuid(), metaInformation.getColumnScheme(), fullFilePath);
+    }
+
+    public String getTableName() {
+      return tableName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof SqlIndividualTimeSeriesMetaInformation that)) return false;
+      if (!super.equals(o)) return false;
+      return tableName.equals(that.tableName);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(super.hashCode(), tableName);
+    }
+
+    @Override
+    public String toString() {
+      return "SqlIndividualTimeSeriesMetaInformation{"
+          + "uuid="
+          + getUuid()
+          + ", columnScheme="
+          + getColumnScheme()
+          + ", tableName='"
+          + tableName
+          + '\''
+          + '}';
+    }
   }
 }

--- a/src/main/java/edu/ie3/datamodel/io/connectors/SqlConnector.java
+++ b/src/main/java/edu/ie3/datamodel/io/connectors/SqlConnector.java
@@ -159,7 +159,10 @@ public class SqlConnector implements DataConnector {
     return insensitiveFieldsToAttributes;
   }
 
-  /** Enhancing the {@link IndividualTimeSeriesMetaInformation} with the full path to csv file */
+  /**
+   * Enhancing the {@link IndividualTimeSeriesMetaInformation} with the name of the table containing
+   * the time series
+   */
   public static class SqlIndividualTimeSeriesMetaInformation
       extends IndividualTimeSeriesMetaInformation {
     private final String tableName;

--- a/src/main/java/edu/ie3/datamodel/io/naming/DataSourceMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/naming/DataSourceMetaInformation.java
@@ -3,16 +3,16 @@
  * Institute of Energy Systems, Energy Efficiency and Energy Economics,
  * Research group Distribution grid planning and operation
 */
-package edu.ie3.datamodel.io.csv;
+package edu.ie3.datamodel.io.naming;
 
 import java.util.Objects;
 import java.util.UUID;
 
-/** Meta information, that can be derived from a certain file name */
-public abstract class FileNameMetaInformation {
+/** Meta information, that can be derived from a data source */
+public abstract class DataSourceMetaInformation {
   private final UUID uuid;
 
-  protected FileNameMetaInformation(UUID uuid) {
+  protected DataSourceMetaInformation(UUID uuid) {
     this.uuid = uuid;
   }
 
@@ -23,7 +23,7 @@ public abstract class FileNameMetaInformation {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof FileNameMetaInformation that)) return false;
+    if (!(o instanceof DataSourceMetaInformation that)) return false;
     return uuid.equals(that.uuid);
   }
 
@@ -34,6 +34,6 @@ public abstract class FileNameMetaInformation {
 
   @Override
   public String toString() {
-    return "FileNameMetaInformation{" + "uuid=" + uuid + '}';
+    return "DataSourceMetaInformation{" + "uuid=" + uuid + '}';
   }
 }

--- a/src/main/java/edu/ie3/datamodel/io/naming/DataSourceMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/naming/DataSourceMetaInformation.java
@@ -8,7 +8,7 @@ package edu.ie3.datamodel.io.naming;
 import java.util.Objects;
 import java.util.UUID;
 
-/** Meta information, that can be derived from a data source */
+/** Meta information, that describe a certain data source */
 public abstract class DataSourceMetaInformation {
   private final UUID uuid;
 

--- a/src/main/java/edu/ie3/datamodel/io/naming/EntityPersistenceNamingStrategy.java
+++ b/src/main/java/edu/ie3/datamodel/io/naming/EntityPersistenceNamingStrategy.java
@@ -5,9 +5,9 @@
 */
 package edu.ie3.datamodel.io.naming;
 
-import edu.ie3.datamodel.io.csv.timeseries.ColumnScheme;
-import edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation;
-import edu.ie3.datamodel.io.csv.timeseries.LoadProfileTimeSeriesMetaInformation;
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme;
+import edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation;
+import edu.ie3.datamodel.io.naming.timeseries.LoadProfileTimeSeriesMetaInformation;
 import edu.ie3.datamodel.io.source.TimeSeriesMappingSource;
 import edu.ie3.datamodel.models.UniqueEntity;
 import edu.ie3.datamodel.models.input.*;

--- a/src/main/java/edu/ie3/datamodel/io/naming/EntityPersistenceNamingStrategy.java
+++ b/src/main/java/edu/ie3/datamodel/io/naming/EntityPersistenceNamingStrategy.java
@@ -42,9 +42,9 @@ public class EntityPersistenceNamingStrategy {
   private static final String UUID_STRING =
       "[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}";
   /**
-   * Regex to match the naming convention of a file for an individual time series. The column scheme
-   * is accessible via the named capturing group "columnScheme". The time series' UUID is accessible
-   * by the named capturing group "uuid"
+   * Regex to match the naming convention of a source for an individual time series. The column
+   * scheme is accessible via the named capturing group "columnScheme". The time series' UUID is
+   * accessible by the named capturing group "uuid"
    */
   private static final Pattern INDIVIDUAL_TIME_SERIES_PATTERN =
       Pattern.compile("its_(?<columnScheme>[a-zA-Z]{1,11})_(?<uuid>" + UUID_STRING + ")");
@@ -125,17 +125,18 @@ public class EntityPersistenceNamingStrategy {
   }
 
   /**
-   * Extracts meta information from a valid file name for an individual time series
+   * Extracts meta information from a valid source name for an individual time series
    *
-   * @param fileName File name to extract information from
-   * @return Meta information form individual time series file name
+   * @param sourceName Name of the source to extract information from, e.g. file name or SQL table
+   *     name
+   * @return Meta information form individual time series source name
    */
   public IndividualTimeSeriesMetaInformation extractIndividualTimesSeriesMetaInformation(
-      String fileName) {
-    Matcher matcher = getIndividualTimeSeriesPattern().matcher(fileName);
+      String sourceName) {
+    Matcher matcher = getIndividualTimeSeriesPattern().matcher(sourceName);
     if (!matcher.matches())
       throw new IllegalArgumentException(
-          "Cannot extract meta information on individual time series from '" + fileName + "'.");
+          "Cannot extract meta information on individual time series from '" + sourceName + "'.");
 
     String columnSchemeKey = matcher.group("columnScheme");
     ColumnScheme columnScheme =
@@ -189,7 +190,7 @@ public class EntityPersistenceNamingStrategy {
   /**
    * Returns the name of the entity, that should be used for persistence.
    *
-   * @param cls Targeted class of the given file
+   * @param cls Targeted class of the given entity
    * @return The name of the entity
    */
   public Optional<String> getEntityName(Class<? extends UniqueEntity> cls) {

--- a/src/main/java/edu/ie3/datamodel/io/naming/FileNamingStrategy.java
+++ b/src/main/java/edu/ie3/datamodel/io/naming/FileNamingStrategy.java
@@ -6,7 +6,6 @@
 package edu.ie3.datamodel.io.naming;
 
 import edu.ie3.datamodel.io.IoUtil;
-import edu.ie3.datamodel.io.csv.FileNameMetaInformation;
 import edu.ie3.datamodel.models.UniqueEntity;
 import edu.ie3.datamodel.models.timeseries.TimeSeries;
 import edu.ie3.datamodel.models.timeseries.TimeSeriesEntry;
@@ -218,7 +217,7 @@ public class FileNamingStrategy {
    * @param path Path to the file
    * @return The meeting meta information
    */
-  public FileNameMetaInformation extractTimeSeriesMetaInformation(Path path) {
+  public DataSourceMetaInformation extractTimeSeriesMetaInformation(Path path) {
     /* Extract file name from possibly fully qualified path */
     Path fileName = path.getFileName();
     if (fileName == null)
@@ -233,7 +232,7 @@ public class FileNamingStrategy {
    * @param fileName File name
    * @return The meeting meta information
    */
-  public FileNameMetaInformation extractTimeSeriesMetaInformation(String fileName) {
+  public DataSourceMetaInformation extractTimeSeriesMetaInformation(String fileName) {
     /* Remove the file ending (ending limited to 255 chars, which is the max file name allowed in NTFS and ext4) */
     String withoutEnding = fileName.replaceAll("(?:\\.[^\\\\/\\s]{1,255}){1,2}$", "");
 

--- a/src/main/java/edu/ie3/datamodel/io/naming/timeseries/ColumnScheme.java
+++ b/src/main/java/edu/ie3/datamodel/io/naming/timeseries/ColumnScheme.java
@@ -3,7 +3,7 @@
  * Institute of Energy Systems, Energy Efficiency and Energy Economics,
  * Research group Distribution grid planning and operation
 */
-package edu.ie3.datamodel.io.csv.timeseries;
+package edu.ie3.datamodel.io.naming.timeseries;
 
 import edu.ie3.datamodel.models.value.*;
 import edu.ie3.util.StringUtils;

--- a/src/main/java/edu/ie3/datamodel/io/naming/timeseries/IndividualTimeSeriesMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/naming/timeseries/IndividualTimeSeriesMetaInformation.java
@@ -9,7 +9,7 @@ import edu.ie3.datamodel.io.naming.DataSourceMetaInformation;
 import java.util.Objects;
 import java.util.UUID;
 
-/** Specific meta information, that can be derived from a individual time series file */
+/** Specific meta information, that can be derived from an individual time series file */
 public class IndividualTimeSeriesMetaInformation extends DataSourceMetaInformation {
   private final ColumnScheme columnScheme;
 

--- a/src/main/java/edu/ie3/datamodel/io/naming/timeseries/IndividualTimeSeriesMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/naming/timeseries/IndividualTimeSeriesMetaInformation.java
@@ -3,14 +3,14 @@
  * Institute of Energy Systems, Energy Efficiency and Energy Economics,
  * Research group Distribution grid planning and operation
 */
-package edu.ie3.datamodel.io.csv.timeseries;
+package edu.ie3.datamodel.io.naming.timeseries;
 
-import edu.ie3.datamodel.io.csv.FileNameMetaInformation;
+import edu.ie3.datamodel.io.naming.DataSourceMetaInformation;
 import java.util.Objects;
 import java.util.UUID;
 
 /** Specific meta information, that can be derived from a individual time series file */
-public class IndividualTimeSeriesMetaInformation extends FileNameMetaInformation {
+public class IndividualTimeSeriesMetaInformation extends DataSourceMetaInformation {
   private final ColumnScheme columnScheme;
 
   public IndividualTimeSeriesMetaInformation(UUID uuid, ColumnScheme columnScheme) {
@@ -25,9 +25,8 @@ public class IndividualTimeSeriesMetaInformation extends FileNameMetaInformation
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof IndividualTimeSeriesMetaInformation)) return false;
+    if (!(o instanceof IndividualTimeSeriesMetaInformation that)) return false;
     if (!super.equals(o)) return false;
-    IndividualTimeSeriesMetaInformation that = (IndividualTimeSeriesMetaInformation) o;
     return columnScheme == that.columnScheme;
   }
 

--- a/src/main/java/edu/ie3/datamodel/io/naming/timeseries/LoadProfileTimeSeriesMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/naming/timeseries/LoadProfileTimeSeriesMetaInformation.java
@@ -3,14 +3,14 @@
  * Institute of Energy Systems, Energy Efficiency and Energy Economics,
  * Research group Distribution grid planning and operation
 */
-package edu.ie3.datamodel.io.csv.timeseries;
+package edu.ie3.datamodel.io.naming.timeseries;
 
-import edu.ie3.datamodel.io.csv.FileNameMetaInformation;
+import edu.ie3.datamodel.io.naming.DataSourceMetaInformation;
 import java.util.Objects;
 import java.util.UUID;
 
 /** Specific meta information, that can be derived from a load profile time series file */
-public class LoadProfileTimeSeriesMetaInformation extends FileNameMetaInformation {
+public class LoadProfileTimeSeriesMetaInformation extends DataSourceMetaInformation {
   private final String profile;
 
   public LoadProfileTimeSeriesMetaInformation(UUID uuid, String profile) {
@@ -25,9 +25,8 @@ public class LoadProfileTimeSeriesMetaInformation extends FileNameMetaInformatio
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof LoadProfileTimeSeriesMetaInformation)) return false;
+    if (!(o instanceof LoadProfileTimeSeriesMetaInformation that)) return false;
     if (!super.equals(o)) return false;
-    LoadProfileTimeSeriesMetaInformation that = (LoadProfileTimeSeriesMetaInformation) o;
     return profile.equals(that.profile);
   }
 

--- a/src/main/java/edu/ie3/datamodel/io/source/TimeSeriesMappingSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/TimeSeriesMappingSource.java
@@ -5,7 +5,7 @@
 */
 package edu.ie3.datamodel.io.source;
 
-import edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation;
+import edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation;
 import edu.ie3.datamodel.models.input.InputEntity;
 import java.util.Map;
 import java.util.Objects;
@@ -64,9 +64,8 @@ public interface TimeSeriesMappingSource extends DataSource {
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (!(o instanceof MappingEntry)) return false;
+      if (!(o instanceof MappingEntry that)) return false;
       if (!super.equals(o)) return false;
-      MappingEntry that = (MappingEntry) o;
       return participant.equals(that.participant) && timeSeries.equals(that.timeSeries);
     }
 

--- a/src/main/java/edu/ie3/datamodel/io/source/TimeSeriesSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/TimeSeriesSource.java
@@ -5,9 +5,9 @@
 */
 package edu.ie3.datamodel.io.source;
 
-import static edu.ie3.datamodel.io.csv.timeseries.ColumnScheme.*;
+import static edu.ie3.datamodel.io.naming.timeseries.ColumnScheme.*;
 
-import edu.ie3.datamodel.io.csv.timeseries.ColumnScheme;
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme;
 import edu.ie3.datamodel.models.timeseries.individual.IndividualTimeSeries;
 import edu.ie3.datamodel.models.value.Value;
 import edu.ie3.util.interval.ClosedInterval;

--- a/src/main/java/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesMappingSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesMappingSource.java
@@ -5,10 +5,10 @@
 */
 package edu.ie3.datamodel.io.source.csv;
 
-import edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation;
 import edu.ie3.datamodel.io.factory.SimpleEntityData;
 import edu.ie3.datamodel.io.factory.timeseries.TimeSeriesMappingFactory;
 import edu.ie3.datamodel.io.naming.FileNamingStrategy;
+import edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation;
 import edu.ie3.datamodel.io.source.TimeSeriesMappingSource;
 import java.util.Map;
 import java.util.Optional;

--- a/src/main/java/edu/ie3/datamodel/io/source/csv/CsvWeatherSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/csv/CsvWeatherSource.java
@@ -6,11 +6,11 @@
 package edu.ie3.datamodel.io.source.csv;
 
 import edu.ie3.datamodel.io.connectors.CsvFileConnector;
-import edu.ie3.datamodel.io.csv.timeseries.ColumnScheme;
 import edu.ie3.datamodel.io.factory.timeseries.IdCoordinateFactory;
 import edu.ie3.datamodel.io.factory.timeseries.TimeBasedWeatherValueData;
 import edu.ie3.datamodel.io.factory.timeseries.TimeBasedWeatherValueFactory;
 import edu.ie3.datamodel.io.naming.FileNamingStrategy;
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme;
 import edu.ie3.datamodel.io.source.IdCoordinateSource;
 import edu.ie3.datamodel.io.source.WeatherSource;
 import edu.ie3.datamodel.models.UniqueEntity;

--- a/src/main/java/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesMappingSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesMappingSource.java
@@ -6,10 +6,10 @@
 package edu.ie3.datamodel.io.source.sql;
 
 import edu.ie3.datamodel.io.connectors.SqlConnector;
-import edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation;
 import edu.ie3.datamodel.io.factory.SimpleEntityData;
 import edu.ie3.datamodel.io.factory.timeseries.TimeSeriesMappingFactory;
 import edu.ie3.datamodel.io.naming.EntityPersistenceNamingStrategy;
+import edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation;
 import edu.ie3.datamodel.io.source.TimeSeriesMappingSource;
 import java.util.Map;
 import java.util.Optional;
@@ -47,7 +47,14 @@ public class SqlTimeSeriesMappingSource extends SqlDataSource<TimeSeriesMappingS
   public Optional<IndividualTimeSeriesMetaInformation> getTimeSeriesMetaInformation(
       UUID timeSeriesUuid) {
     return getDbTableName(null, "%" + timeSeriesUuid.toString())
-        .map(entityPersistenceNamingStrategy::extractIndividualTimesSeriesMetaInformation);
+        .map(
+            tableName -> {
+              IndividualTimeSeriesMetaInformation metaInformation =
+                  entityPersistenceNamingStrategy.extractIndividualTimesSeriesMetaInformation(
+                      tableName);
+              return new SqlConnector.SqlIndividualTimeSeriesMetaInformation(
+                  metaInformation, tableName);
+            });
   }
 
   @Override

--- a/src/main/java/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesMappingSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesMappingSource.java
@@ -22,6 +22,7 @@ public class SqlTimeSeriesMappingSource extends SqlDataSource<TimeSeriesMappingS
 
   private final EntityPersistenceNamingStrategy entityPersistenceNamingStrategy;
   private final String queryFull;
+  private final String schemaName;
 
   public SqlTimeSeriesMappingSource(
       SqlConnector connector,
@@ -35,6 +36,8 @@ public class SqlTimeSeriesMappingSource extends SqlDataSource<TimeSeriesMappingS
             .getEntityName(MappingEntry.class)
             .orElseThrow(() -> new RuntimeException(""));
     this.queryFull = createBaseQueryString(schemaName, tableName);
+
+    this.schemaName = schemaName;
   }
 
   @Override
@@ -46,7 +49,7 @@ public class SqlTimeSeriesMappingSource extends SqlDataSource<TimeSeriesMappingS
   @Override
   public Optional<IndividualTimeSeriesMetaInformation> getTimeSeriesMetaInformation(
       UUID timeSeriesUuid) {
-    return getDbTableName(null, "%" + timeSeriesUuid.toString())
+    return getDbTableName(schemaName, "%" + timeSeriesUuid.toString())
         .map(
             tableName -> {
               IndividualTimeSeriesMetaInformation metaInformation =

--- a/src/main/java/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesSource.java
@@ -7,7 +7,6 @@ package edu.ie3.datamodel.io.source.sql;
 
 import edu.ie3.datamodel.exceptions.SourceException;
 import edu.ie3.datamodel.io.connectors.SqlConnector;
-import edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation;
 import edu.ie3.datamodel.io.factory.timeseries.SimpleTimeBasedValueData;
 import edu.ie3.datamodel.io.factory.timeseries.TimeBasedSimpleValueFactory;
 import edu.ie3.datamodel.io.source.TimeSeriesSource;
@@ -41,7 +40,6 @@ public class SqlTimeSeriesSource<V extends Value> extends SqlDataSource<TimeBase
    *
    * @param connector the connector needed for database connection
    * @param schemaName the database schema to use
-   * @param tableName the database table to use
    * @param metaInformation the time series meta information
    * @param timePattern the pattern of time values
    * @return a SqlTimeSeriesSource for given time series table
@@ -50,8 +48,7 @@ public class SqlTimeSeriesSource<V extends Value> extends SqlDataSource<TimeBase
   public static SqlTimeSeriesSource<? extends Value> getSource(
       SqlConnector connector,
       String schemaName,
-      String tableName,
-      IndividualTimeSeriesMetaInformation metaInformation,
+      SqlConnector.SqlIndividualTimeSeriesMetaInformation metaInformation,
       String timePattern)
       throws SourceException {
     if (!TimeSeriesSource.isSchemeAccepted(metaInformation.getColumnScheme()))
@@ -61,7 +58,12 @@ public class SqlTimeSeriesSource<V extends Value> extends SqlDataSource<TimeBase
     Class<? extends Value> valClass = metaInformation.getColumnScheme().getValueClass();
 
     return create(
-        connector, schemaName, tableName, metaInformation.getUuid(), valClass, timePattern);
+        connector,
+        schemaName,
+        metaInformation.getTableName(),
+        metaInformation.getUuid(),
+        valClass,
+        timePattern);
   }
 
   private static <T extends Value> SqlTimeSeriesSource<T> create(

--- a/src/test/groovy/edu/ie3/datamodel/io/connectors/CsvFileConnectorTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/connectors/CsvFileConnectorTest.groovy
@@ -9,7 +9,7 @@ import edu.ie3.datamodel.exceptions.ConnectorException
 import edu.ie3.datamodel.io.naming.FileNamingStrategy
 import edu.ie3.datamodel.io.csv.CsvFileDefinition
 import edu.ie3.datamodel.io.naming.DefaultDirectoryHierarchy
-import edu.ie3.datamodel.io.csv.timeseries.ColumnScheme
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme
 import edu.ie3.datamodel.io.naming.EntityPersistenceNamingStrategy
 import edu.ie3.datamodel.models.StandardUnits
 import edu.ie3.datamodel.models.input.NodeInput

--- a/src/test/groovy/edu/ie3/datamodel/io/connectors/SqlIndividualTimeSeriesMetaInformationTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/connectors/SqlIndividualTimeSeriesMetaInformationTest.groovy
@@ -1,0 +1,51 @@
+package edu.ie3.datamodel.io.connectors
+
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme
+import edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation
+import spock.lang.Shared
+import spock.lang.Specification
+
+class SqlIndividualTimeSeriesMetaInformationTest extends Specification {
+
+    @Shared
+    private final UUID randomUUID = UUID.fromString("80d1bbec-79df-4ae2-b60a-34a2c3f77408")
+
+    @Shared
+    private final ColumnScheme columnScheme = ColumnScheme.ACTIVE_POWER
+
+    @Shared
+    private final String tableName = "its_p_80d1bbec-79df-4ae2-b60a-34a2c3f77408"
+
+    def "SqlIndividualTimeSeriesMetaInformation is properly created with standard constructor"() {
+        when:
+        def sqlMetaInf = new SqlConnector.SqlIndividualTimeSeriesMetaInformation(randomUUID, columnScheme, tableName)
+
+        then:
+        sqlMetaInf.getUuid() == randomUUID
+        sqlMetaInf.getColumnScheme() == columnScheme
+        sqlMetaInf.getTableName() == tableName
+    }
+
+    def "SqlIndividualTimeSeriesMetaInformation is properly created with secondary constructor"() {
+        given:
+        def metaInf = new IndividualTimeSeriesMetaInformation(randomUUID, columnScheme)
+
+        when:
+        def sqlMetaInf = new SqlConnector.SqlIndividualTimeSeriesMetaInformation(metaInf, tableName)
+
+        then:
+        sqlMetaInf.getUuid() == randomUUID
+        sqlMetaInf.getColumnScheme() == columnScheme
+        sqlMetaInf.getTableName() == tableName
+    }
+
+    def "SqlIndividualTimeSeriesMetaInformation returns a proper String representation"() {
+        when:
+        def sqlMetaInf = new SqlConnector.SqlIndividualTimeSeriesMetaInformation(randomUUID, columnScheme, tableName)
+
+        then:
+        sqlMetaInf.toString() ==
+                "SqlIndividualTimeSeriesMetaInformation{uuid=80d1bbec-79df-4ae2-b60a-34a2c3f77408, " +
+                "columnScheme=ACTIVE_POWER, tableName='its_p_80d1bbec-79df-4ae2-b60a-34a2c3f77408'}"
+    }
+}

--- a/src/test/groovy/edu/ie3/datamodel/io/connectors/SqlIndividualTimeSeriesMetaInformationTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/connectors/SqlIndividualTimeSeriesMetaInformationTest.groovy
@@ -21,9 +21,9 @@ class SqlIndividualTimeSeriesMetaInformationTest extends Specification {
         def sqlMetaInf = new SqlConnector.SqlIndividualTimeSeriesMetaInformation(randomUUID, columnScheme, tableName)
 
         then:
-        sqlMetaInf.getUuid() == randomUUID
-        sqlMetaInf.getColumnScheme() == columnScheme
-        sqlMetaInf.getTableName() == tableName
+        sqlMetaInf.uuid == randomUUID
+        sqlMetaInf.columnScheme == columnScheme
+        sqlMetaInf.tableName == tableName
     }
 
     def "SqlIndividualTimeSeriesMetaInformation is properly created with secondary constructor"() {
@@ -34,9 +34,9 @@ class SqlIndividualTimeSeriesMetaInformationTest extends Specification {
         def sqlMetaInf = new SqlConnector.SqlIndividualTimeSeriesMetaInformation(metaInf, tableName)
 
         then:
-        sqlMetaInf.getUuid() == randomUUID
-        sqlMetaInf.getColumnScheme() == columnScheme
-        sqlMetaInf.getTableName() == tableName
+        sqlMetaInf.uuid == randomUUID
+        sqlMetaInf.columnScheme == columnScheme
+        sqlMetaInf.tableName == tableName
     }
 
     def "SqlIndividualTimeSeriesMetaInformation returns a proper String representation"() {

--- a/src/test/groovy/edu/ie3/datamodel/io/csv/timeseries/ColumnSchemeTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/csv/timeseries/ColumnSchemeTest.groovy
@@ -5,7 +5,7 @@
  */
 package edu.ie3.datamodel.io.csv.timeseries
 
-import static edu.ie3.datamodel.io.csv.timeseries.ColumnScheme.*
+import static edu.ie3.datamodel.io.naming.timeseries.ColumnScheme.*
 
 import edu.ie3.datamodel.models.value.EnergyPriceValue
 import edu.ie3.datamodel.models.value.HeatAndPValue

--- a/src/test/groovy/edu/ie3/datamodel/io/naming/FileNamingStrategyTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/naming/FileNamingStrategyTest.groovy
@@ -5,9 +5,9 @@
  */
 package edu.ie3.datamodel.io.naming
 
-import edu.ie3.datamodel.io.csv.timeseries.ColumnScheme
-import edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation
-import edu.ie3.datamodel.io.csv.timeseries.LoadProfileTimeSeriesMetaInformation
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme
+import edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation
+import edu.ie3.datamodel.io.naming.timeseries.LoadProfileTimeSeriesMetaInformation
 import edu.ie3.datamodel.io.source.TimeSeriesMappingSource
 import edu.ie3.datamodel.models.BdewLoadProfile
 import edu.ie3.datamodel.models.UniqueEntity

--- a/src/test/groovy/edu/ie3/datamodel/io/naming/timeseries/ColumnSchemeTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/naming/timeseries/ColumnSchemeTest.groovy
@@ -3,7 +3,7 @@
  * Institute of Energy Systems, Energy Efficiency and Energy Economics,
  * Research group Distribution grid planning and operation
  */
-package edu.ie3.datamodel.io.csv.timeseries
+package edu.ie3.datamodel.io.naming.timeseries
 
 import static edu.ie3.datamodel.io.naming.timeseries.ColumnScheme.*
 

--- a/src/test/groovy/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesMappingSourceIT.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesMappingSourceIT.groovy
@@ -7,7 +7,7 @@ package edu.ie3.datamodel.io.source.csv
 
 import edu.ie3.datamodel.io.naming.FileNamingStrategy
 import edu.ie3.datamodel.io.connectors.CsvFileConnector
-import edu.ie3.datamodel.io.csv.timeseries.ColumnScheme
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme
 import edu.ie3.datamodel.io.source.TimeSeriesMappingSource
 import spock.lang.Shared
 import spock.lang.Specification

--- a/src/test/groovy/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesSourceTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesSourceTest.groovy
@@ -11,7 +11,7 @@ import static edu.ie3.datamodel.models.StandardUnits.ENERGY_PRICE
 
 import edu.ie3.datamodel.exceptions.SourceException
 import edu.ie3.datamodel.io.connectors.CsvFileConnector
-import edu.ie3.datamodel.io.csv.timeseries.ColumnScheme
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme
 import edu.ie3.datamodel.io.factory.timeseries.TimeBasedSimpleValueFactory
 import edu.ie3.datamodel.models.timeseries.individual.TimeBasedValue
 import edu.ie3.datamodel.models.value.*

--- a/src/test/groovy/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesMappingSourceIT.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesMappingSourceIT.groovy
@@ -6,9 +6,8 @@
 package edu.ie3.datamodel.io.source.sql
 
 import edu.ie3.datamodel.io.connectors.SqlConnector
-import edu.ie3.datamodel.io.csv.timeseries.ColumnScheme
-import edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation
 import edu.ie3.datamodel.io.naming.EntityPersistenceNamingStrategy
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme
 import org.testcontainers.containers.Container
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.spock.Testcontainers
@@ -93,9 +92,10 @@ class SqlTimeSeriesMappingSourceIT extends Specification {
 	def "A sql time series mapping source returns correct meta information for an existing time series"() {
 		given:
 		def timeSeriesUuid = UUID.fromString("9185b8c1-86ba-4a16-8dea-5ac898e8caa5")
-		def expected = new IndividualTimeSeriesMetaInformation(
+		def expected = new SqlConnector.SqlIndividualTimeSeriesMetaInformation(
 				timeSeriesUuid,
-				ColumnScheme.ACTIVE_POWER)
+				ColumnScheme.ACTIVE_POWER,
+				"its_p_9185b8c1-86ba-4a16-8dea-5ac898e8caa5")
 
 		when:
 		def actual = source.getTimeSeriesMetaInformation(timeSeriesUuid)

--- a/src/test/groovy/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesSourceIT.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesSourceIT.groovy
@@ -9,8 +9,7 @@ import static edu.ie3.test.common.TimeSeriesSourceTestData.*
 
 import edu.ie3.datamodel.exceptions.SourceException
 import edu.ie3.datamodel.io.connectors.SqlConnector
-import edu.ie3.datamodel.io.csv.timeseries.ColumnScheme
-import edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme
 import edu.ie3.datamodel.models.value.*
 import edu.ie3.util.interval.ClosedInterval
 import org.testcontainers.containers.Container
@@ -64,21 +63,22 @@ class SqlTimeSeriesSourceIT extends Specification {
 		}
 
 		connector = new SqlConnector(postgreSQLContainer.jdbcUrl, postgreSQLContainer.username, postgreSQLContainer.password)
-		def metaInformation = new IndividualTimeSeriesMetaInformation(
+		def metaInformation = new SqlConnector.SqlIndividualTimeSeriesMetaInformation(
 				timeSeriesUuid,
-				ColumnScheme.ACTIVE_POWER
+				ColumnScheme.ACTIVE_POWER,
+				pTableName
 				)
 
-		pSource = SqlTimeSeriesSource.getSource(connector, schemaName, pTableName, metaInformation, "yyyy-MM-dd HH:mm:ss")
+		pSource = SqlTimeSeriesSource.getSource(connector, schemaName, metaInformation, "yyyy-MM-dd HH:mm:ss")
 	}
 
 	def "The factory method in SqlTimeSeriesSource builds a time series source for all supported column types"() {
 		given:
-		def metaInformation = new IndividualTimeSeriesMetaInformation(uuid, columnScheme)
+		def metaInformation = new SqlConnector.SqlIndividualTimeSeriesMetaInformation(uuid, columnScheme, tableName)
 		def timePattern = "yyyy-MM-dd HH:mm:ss"
 
 		when:
-		def actual = SqlTimeSeriesSource.getSource(connector, schemaName, tableName, metaInformation, timePattern)
+		def actual = SqlTimeSeriesSource.getSource(connector, schemaName, metaInformation, timePattern)
 
 		then:
 		actual.timeSeries.entries.size() == amountOfEntries
@@ -96,14 +96,15 @@ class SqlTimeSeriesSourceIT extends Specification {
 
 	def "The factory method in SqlTimeSeriesSource refuses to build time series with unsupported column type"() {
 		given:
-		def metaInformation = new IndividualTimeSeriesMetaInformation(
+		def metaInformation = new SqlConnector.SqlIndividualTimeSeriesMetaInformation(
 				UUID.fromString("8bc9120d-fb9b-4484-b4e3-0cdadf0feea9"),
-				ColumnScheme.WEATHER
+				ColumnScheme.WEATHER,
+				"weather"
 				)
 		def timePattern = "yyyy-MM-dd HH:mm:ss"
 
 		when:
-		SqlTimeSeriesSource.getSource(connector, schemaName, "weather", metaInformation, timePattern)
+		SqlTimeSeriesSource.getSource(connector, schemaName, metaInformation, timePattern)
 
 		then:
 		def e = thrown(SourceException)


### PR DESCRIPTION
Resolves #513 

Additions:
- `SqlConnector.SqlIndividualTimeSeriesMetaInformation` analogous to `CsvFileConnector.CsvIndividualTimeSeriesMetaInformation`

Adapted:
- `SqlTimeSeriesMappingSource`
- Tests

Refactorings:
- Moved from `edu.ie3.datamodel.io.csv` to `edu.ie3.datamodel.io.naming`: `FileNameMetaInformation` (renamed to `DataSourceMetaInformation`)
- Moved from `edu.ie3.datamodel.io.csv.timeseries` to `edu.ie3.datamodel.io.naming.timeseries`: `IndividualTimeSeriesMetaInformation`, `LoadProfileTimeSeriesMetaInformation`, `ColumnScheme`
- (if you think there's a better place, let me know)
