### PR TITLE
Introducing SqlIndividualTimeSeriesMetaInformation & refactorings 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - BREAKING: Transformer's no load susceptance needs to be zero or negative to pass model validation [#378](https://github.com/ie3-institute/PowerSystemDataModel/issues/378)
   - All input data sets for version < 3.0.0 need to be altered!
+- Deprecating: 
+  - `edu.ie3.datamodel.io.csv.timeseries.ColumnScheme`
+  - `edu.ie3.datamodel.io.csv.FileNameMetaInformation`
+  - `edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation`
+  - `edu.ie3.datamodel.io.csv.timeseries.LoadProfileTimeSeriesMetaInformation`
+  - `edu.ie3.datamodel.io.connectors.CsvFileConnector.CsvIndividualTimeSeriesMetaInformation`
+  - and related methods
 
 ## [2.1.0] - 2022-01-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - SQL time series sources (`SqlTimeSeriesSource` and `SqlTimeSeriesMappingSource`) [#467](https://github.com/ie3-institute/PowerSystemDataModel/issues/467)
 - Graph with impedance weighted edges including facilities to create it [#440](https://github.com/ie3-institute/PowerSystemDataModel/issues/440)
+- Introducing `SqlIndividualTimeSeriesMetaInformation` which provides sql table names [#513](https://github.com/ie3-institute/PowerSystemDataModel/issues/513)
 
 ### Fixed
 - Reduced code smells [#492](https://github.com/ie3-institute/PowerSystemDataModel/issues/492)
@@ -26,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - BREAKING: Transformer's no load susceptance needs to be zero or negative to pass model validation [#378](https://github.com/ie3-institute/PowerSystemDataModel/issues/378)
   - All input data sets for version < 3.0.0 need to be altered!
-- Deprecating: 
+- Deprecating (as part of [#513](https://github.com/ie3-institute/PowerSystemDataModel/issues/513)): 
   - `edu.ie3.datamodel.io.csv.timeseries.ColumnScheme`
   - `edu.ie3.datamodel.io.csv.FileNameMetaInformation`
   - `edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation`

--- a/src/main/java/edu/ie3/datamodel/io/connectors/CsvFileConnector.java
+++ b/src/main/java/edu/ie3/datamodel/io/connectors/CsvFileConnector.java
@@ -8,8 +8,8 @@ package edu.ie3.datamodel.io.connectors;
 import edu.ie3.datamodel.exceptions.ConnectorException;
 import edu.ie3.datamodel.io.IoUtil;
 import edu.ie3.datamodel.io.csv.*;
-import edu.ie3.datamodel.io.naming.DataSourceMetaInformation;
 import edu.ie3.datamodel.io.naming.FileNamingStrategy;
+import edu.ie3.datamodel.io.naming.TimeSeriesMetaInformation;
 import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme;
 import edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation;
 import edu.ie3.datamodel.models.UniqueEntity;
@@ -230,7 +230,15 @@ public class CsvFileConnector implements DataConnector {
         .map(edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation::new);
   }
 
-  // todo javadoc
+  /**
+   * Get time series meta information for a given uuid.
+   *
+   * <p>This method lazily evaluates the mapping from <i>all</i> time series files to their meta
+   * information.
+   *
+   * @param timeSeriesUuid The time series in question
+   * @return An option on the queried information
+   */
   public Optional<IndividualTimeSeriesMetaInformation> individualTimeSeriesMetaInformation(
       UUID timeSeriesUuid) {
     if (Objects.isNull(individualTimeSeriesMetaInformation))
@@ -257,7 +265,7 @@ public class CsvFileConnector implements DataConnector {
               return new edu.ie3.datamodel.io.csv.CsvIndividualTimeSeriesMetaInformation(
                   metaInformation, filePathWithoutEnding);
             })
-        .collect(Collectors.toMap(DataSourceMetaInformation::getUuid, v -> v));
+        .collect(Collectors.toMap(TimeSeriesMetaInformation::getUuid, v -> v));
   }
 
   /**
@@ -337,7 +345,7 @@ public class CsvFileConnector implements DataConnector {
   private Optional<edu.ie3.datamodel.io.csv.CsvIndividualTimeSeriesMetaInformation>
       buildCsvTimeSeriesMetaInformation(String filePathString, ColumnScheme... columnSchemes) {
     try {
-      DataSourceMetaInformation metaInformation =
+      TimeSeriesMetaInformation metaInformation =
           fileNamingStrategy.timeSeriesMetaInformation(filePathString);
       if (!IndividualTimeSeriesMetaInformation.class.isAssignableFrom(metaInformation.getClass())) {
         log.error(
@@ -445,8 +453,12 @@ public class CsvFileConnector implements DataConnector {
             });
   }
 
-  /** Enhancing the {@link IndividualTimeSeriesMetaInformation} with the full path to csv file */
-  // todo JH javadocs
+  /**
+   * Enhancing the {@link IndividualTimeSeriesMetaInformation} with the full path to csv file
+   *
+   * @deprecated since 3.0. Use {@link
+   *     edu.ie3.datamodel.io.csv.CsvIndividualTimeSeriesMetaInformation} instead
+   */
   @Deprecated
   public static class CsvIndividualTimeSeriesMetaInformation
       extends edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation {

--- a/src/main/java/edu/ie3/datamodel/io/connectors/CsvFileConnector.java
+++ b/src/main/java/edu/ie3/datamodel/io/connectors/CsvFileConnector.java
@@ -223,7 +223,7 @@ public class CsvFileConnector implements DataConnector {
    * @return An option on the queried information
    * @deprecated since 3.0. Use {@link #individualTimeSeriesMetaInformation(UUID)} instead
    */
-  @Deprecated
+  @Deprecated(since = "3.0", forRemoval = true)
   public Optional<edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation>
       getIndividualTimeSeriesMetaInformation(UUID timeSeriesUuid) {
     return individualTimeSeriesMetaInformation(timeSeriesUuid)
@@ -459,7 +459,7 @@ public class CsvFileConnector implements DataConnector {
    * @deprecated since 3.0. Use {@link
    *     edu.ie3.datamodel.io.csv.CsvIndividualTimeSeriesMetaInformation} instead
    */
-  @Deprecated
+  @Deprecated(since = "3.0", forRemoval = true)
   public static class CsvIndividualTimeSeriesMetaInformation
       extends edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation {
     private final String fullFilePath;

--- a/src/main/java/edu/ie3/datamodel/io/csv/CsvIndividualTimeSeriesMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/csv/CsvIndividualTimeSeriesMetaInformation.java
@@ -1,0 +1,58 @@
+/*
+ * © 2022. TU Dortmund University,
+ * Institute of Energy Systems, Energy Efficiency and Energy Economics,
+ * Research group Distribution grid planning and operation
+*/
+package edu.ie3.datamodel.io.csv;
+
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme;
+import edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation;
+import java.util.Objects;
+import java.util.UUID;
+
+/** Enhancing the {@link IndividualTimeSeriesMetaInformation} with the full path to csv file */
+public class CsvIndividualTimeSeriesMetaInformation extends IndividualTimeSeriesMetaInformation {
+  private final String fullFilePath;
+
+  public CsvIndividualTimeSeriesMetaInformation(
+      UUID uuid, ColumnScheme columnScheme, String fullFilePath) {
+    super(uuid, columnScheme);
+    this.fullFilePath = fullFilePath;
+  }
+
+  public CsvIndividualTimeSeriesMetaInformation(
+      IndividualTimeSeriesMetaInformation metaInformation, String fullFilePath) {
+    this(metaInformation.getUuid(), metaInformation.getColumnScheme(), fullFilePath);
+  }
+
+  public String getFullFilePath() {
+    return fullFilePath;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof CsvIndividualTimeSeriesMetaInformation)) return false;
+    if (!super.equals(o)) return false;
+    CsvIndividualTimeSeriesMetaInformation that = (CsvIndividualTimeSeriesMetaInformation) o;
+    return fullFilePath.equals(that.fullFilePath);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), fullFilePath);
+  }
+
+  @Override
+  public String toString() {
+    return "CsvIndividualTimeSeriesMetaInformation{"
+        + "uuid="
+        + getUuid()
+        + ", columnScheme="
+        + getColumnScheme()
+        + ", fullFilePath='"
+        + fullFilePath
+        + '\''
+        + '}';
+  }
+}

--- a/src/main/java/edu/ie3/datamodel/io/csv/CsvIndividualTimeSeriesMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/csv/CsvIndividualTimeSeriesMetaInformation.java
@@ -32,9 +32,8 @@ public class CsvIndividualTimeSeriesMetaInformation extends IndividualTimeSeries
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof CsvIndividualTimeSeriesMetaInformation)) return false;
+    if (!(o instanceof CsvIndividualTimeSeriesMetaInformation that)) return false;
     if (!super.equals(o)) return false;
-    CsvIndividualTimeSeriesMetaInformation that = (CsvIndividualTimeSeriesMetaInformation) o;
     return fullFilePath.equals(that.fullFilePath);
   }
 

--- a/src/main/java/edu/ie3/datamodel/io/csv/FileNameMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/csv/FileNameMetaInformation.java
@@ -5,13 +5,14 @@
 */
 package edu.ie3.datamodel.io.csv;
 
+import edu.ie3.datamodel.io.naming.TimeSeriesMetaInformation;
 import java.util.Objects;
 import java.util.UUID;
 
 /**
  * Meta information, that can be derived from a certain file name
  *
- * @deprecated since 3.0. Use {@link edu.ie3.datamodel.io.naming.DataSourceMetaInformation} instead
+ * @deprecated since 3.0. Use {@link TimeSeriesMetaInformation} instead
  */
 @Deprecated
 public abstract class FileNameMetaInformation {

--- a/src/main/java/edu/ie3/datamodel/io/csv/FileNameMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/csv/FileNameMetaInformation.java
@@ -5,14 +5,13 @@
 */
 package edu.ie3.datamodel.io.csv;
 
-import edu.ie3.datamodel.io.naming.TimeSeriesMetaInformation;
 import java.util.Objects;
 import java.util.UUID;
 
 /**
  * Meta information, that can be derived from a certain file name
  *
- * @deprecated since 3.0. Use {@link TimeSeriesMetaInformation} instead
+ * @deprecated since 3.0. Use {@link edu.ie3.datamodel.io.naming.TimeSeriesMetaInformation} instead
  */
 @Deprecated(since = "3.0", forRemoval = true)
 public abstract class FileNameMetaInformation {

--- a/src/main/java/edu/ie3/datamodel/io/csv/FileNameMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/csv/FileNameMetaInformation.java
@@ -14,7 +14,7 @@ import java.util.UUID;
  *
  * @deprecated since 3.0. Use {@link TimeSeriesMetaInformation} instead
  */
-@Deprecated
+@Deprecated(since = "3.0", forRemoval = true)
 public abstract class FileNameMetaInformation {
   private final UUID uuid;
 

--- a/src/main/java/edu/ie3/datamodel/io/csv/timeseries/ColumnScheme.java
+++ b/src/main/java/edu/ie3/datamodel/io/csv/timeseries/ColumnScheme.java
@@ -11,8 +11,11 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
 
-/** Yet supported column schemes in individual time series */
-// todo JH javadoc
+/**
+ * Yet supported column schemes in individual time series
+ *
+ * @deprecated since 3.0. Use {@link edu.ie3.datamodel.io.naming.timeseries.ColumnScheme} instead
+ */
 @Deprecated
 public enum ColumnScheme {
   ENERGY_PRICE("c", EnergyPriceValue.class),

--- a/src/main/java/edu/ie3/datamodel/io/csv/timeseries/ColumnScheme.java
+++ b/src/main/java/edu/ie3/datamodel/io/csv/timeseries/ColumnScheme.java
@@ -16,7 +16,7 @@ import java.util.Optional;
  *
  * @deprecated since 3.0. Use {@link edu.ie3.datamodel.io.naming.timeseries.ColumnScheme} instead
  */
-@Deprecated
+@Deprecated(since = "3.0", forRemoval = true)
 public enum ColumnScheme {
   ENERGY_PRICE("c", EnergyPriceValue.class),
   ACTIVE_POWER("p", PValue.class),

--- a/src/main/java/edu/ie3/datamodel/io/csv/timeseries/IndividualTimeSeriesMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/csv/timeseries/IndividualTimeSeriesMetaInformation.java
@@ -9,13 +9,33 @@ import edu.ie3.datamodel.io.csv.FileNameMetaInformation;
 import java.util.Objects;
 import java.util.UUID;
 
-/** Specific meta information, that can be derived from a individual time series file */
+/**
+ * Specific meta information, that can be derived from a individual time series file
+ *
+ * @deprecated since 3.0. Use {@link
+ *     edu.ie3.datamodel.io.naming.IndividualTimeSeriesMetaInformation} instead
+ */
+@Deprecated
 public class IndividualTimeSeriesMetaInformation extends FileNameMetaInformation {
   private final ColumnScheme columnScheme;
 
   public IndividualTimeSeriesMetaInformation(UUID uuid, ColumnScheme columnScheme) {
     super(uuid);
     this.columnScheme = columnScheme;
+  }
+
+  public IndividualTimeSeriesMetaInformation(
+      edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation
+          newMetaInformation) {
+    super(newMetaInformation.getUuid());
+    this.columnScheme =
+        ColumnScheme.parse(newMetaInformation.getColumnScheme().toString())
+            .orElseThrow(
+                () ->
+                    new RuntimeException(
+                        "Cannot convert new column scheme "
+                            + newMetaInformation.getColumnScheme().getScheme()
+                            + " to deprecated column scheme!"));
   }
 
   public ColumnScheme getColumnScheme() {

--- a/src/main/java/edu/ie3/datamodel/io/csv/timeseries/IndividualTimeSeriesMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/csv/timeseries/IndividualTimeSeriesMetaInformation.java
@@ -15,7 +15,7 @@ import java.util.UUID;
  * @deprecated since 3.0. Use {@link
  *     edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation} instead
  */
-@Deprecated
+@Deprecated(since = "3.0", forRemoval = true)
 public class IndividualTimeSeriesMetaInformation extends FileNameMetaInformation {
   private final ColumnScheme columnScheme;
 

--- a/src/main/java/edu/ie3/datamodel/io/csv/timeseries/IndividualTimeSeriesMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/csv/timeseries/IndividualTimeSeriesMetaInformation.java
@@ -13,7 +13,7 @@ import java.util.UUID;
  * Specific meta information, that can be derived from a individual time series file
  *
  * @deprecated since 3.0. Use {@link
- *     edu.ie3.datamodel.io.naming.IndividualTimeSeriesMetaInformation} instead
+ *     edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation} instead
  */
 @Deprecated
 public class IndividualTimeSeriesMetaInformation extends FileNameMetaInformation {

--- a/src/main/java/edu/ie3/datamodel/io/csv/timeseries/LoadProfileTimeSeriesMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/csv/timeseries/LoadProfileTimeSeriesMetaInformation.java
@@ -13,7 +13,7 @@ import java.util.UUID;
  * Specific meta information, that can be derived from a load profile time series file
  *
  * @deprecated since 3.0. Use {@link
- *     edu.ie3.datamodel.io.naming.LoadProfileTimeSeriesMetaInformation} instead
+ *     edu.ie3.datamodel.io.naming.timeseries.LoadProfileTimeSeriesMetaInformation} instead
  */
 @Deprecated
 public class LoadProfileTimeSeriesMetaInformation extends FileNameMetaInformation {

--- a/src/main/java/edu/ie3/datamodel/io/csv/timeseries/LoadProfileTimeSeriesMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/csv/timeseries/LoadProfileTimeSeriesMetaInformation.java
@@ -15,7 +15,7 @@ import java.util.UUID;
  * @deprecated since 3.0. Use {@link
  *     edu.ie3.datamodel.io.naming.timeseries.LoadProfileTimeSeriesMetaInformation} instead
  */
-@Deprecated
+@Deprecated(since = "3.0", forRemoval = true)
 public class LoadProfileTimeSeriesMetaInformation extends FileNameMetaInformation {
   private final String profile;
 

--- a/src/main/java/edu/ie3/datamodel/io/naming/DataSourceMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/naming/DataSourceMetaInformation.java
@@ -3,21 +3,16 @@
  * Institute of Energy Systems, Energy Efficiency and Energy Economics,
  * Research group Distribution grid planning and operation
 */
-package edu.ie3.datamodel.io.csv;
+package edu.ie3.datamodel.io.naming;
 
 import java.util.Objects;
 import java.util.UUID;
 
-/**
- * Meta information, that can be derived from a certain file name
- *
- * @deprecated since 3.0. Use {@link edu.ie3.datamodel.io.naming.DataSourceMetaInformation} instead
- */
-@Deprecated
-public abstract class FileNameMetaInformation {
+/** Meta information, that describe a certain data source */
+public abstract class DataSourceMetaInformation {
   private final UUID uuid;
 
-  protected FileNameMetaInformation(UUID uuid) {
+  protected DataSourceMetaInformation(UUID uuid) {
     this.uuid = uuid;
   }
 
@@ -28,7 +23,7 @@ public abstract class FileNameMetaInformation {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof FileNameMetaInformation that)) return false;
+    if (!(o instanceof DataSourceMetaInformation that)) return false;
     return uuid.equals(that.uuid);
   }
 
@@ -39,6 +34,6 @@ public abstract class FileNameMetaInformation {
 
   @Override
   public String toString() {
-    return "FileNameMetaInformation{" + "uuid=" + uuid + '}';
+    return "DataSourceMetaInformation{" + "uuid=" + uuid + '}';
   }
 }

--- a/src/main/java/edu/ie3/datamodel/io/naming/EntityPersistenceNamingStrategy.java
+++ b/src/main/java/edu/ie3/datamodel/io/naming/EntityPersistenceNamingStrategy.java
@@ -153,17 +153,18 @@ public class EntityPersistenceNamingStrategy {
   }
 
   /**
-   * Extracts meta information from a valid file name for an individual time series
+   * Extracts meta information from a valid source name for an individual time series
    *
-   * @param fileName File name to extract information from
-   * @return Meta information form individual time series file name
+   * @param sourceName Name of the source to extract information from, e.g. file name or SQL table
+   *     name
+   * @return Meta information form individual time series source name
    */
   public IndividualTimeSeriesMetaInformation getIndividualTimesSeriesMetaInformation(
-      String fileName) {
-    Matcher matcher = getIndividualTimeSeriesPattern().matcher(fileName);
+      String sourceName) {
+    Matcher matcher = getIndividualTimeSeriesPattern().matcher(sourceName);
     if (!matcher.matches())
       throw new IllegalArgumentException(
-          "Cannot extract meta information on individual time series from '" + fileName + "'.");
+          "Cannot extract meta information on individual time series from '" + sourceName + "'.");
 
     String columnSchemeKey = matcher.group("columnScheme");
     ColumnScheme columnScheme =

--- a/src/main/java/edu/ie3/datamodel/io/naming/EntityPersistenceNamingStrategy.java
+++ b/src/main/java/edu/ie3/datamodel/io/naming/EntityPersistenceNamingStrategy.java
@@ -132,7 +132,7 @@ public class EntityPersistenceNamingStrategy {
    * @return Meta information form individual time series source name
    * @deprecated since 3.0. Use {@link #getIndividualTimesSeriesMetaInformation(String)} instead
    */
-  @Deprecated
+  @Deprecated(since = "3.0", forRemoval = true)
   public edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation
       extractIndividualTimesSeriesMetaInformation(String sourceName) {
     Matcher matcher = getIndividualTimeSeriesPattern().matcher(sourceName);
@@ -184,7 +184,7 @@ public class EntityPersistenceNamingStrategy {
    * @return Meta information form load profile time series file name
    * @deprecated since 3.0. Use {@link #getLoadProfileTimesSeriesMetaInformation(String)} instead
    */
-  @Deprecated
+  @Deprecated(since = "3.0", forRemoval = true)
   public edu.ie3.datamodel.io.csv.timeseries.LoadProfileTimeSeriesMetaInformation
       extractLoadProfileTimesSeriesMetaInformation(String fileName) {
     Matcher matcher = getLoadProfileTimeSeriesPattern().matcher(fileName);

--- a/src/main/java/edu/ie3/datamodel/io/naming/EntityPersistenceNamingStrategy.java
+++ b/src/main/java/edu/ie3/datamodel/io/naming/EntityPersistenceNamingStrategy.java
@@ -130,7 +130,7 @@ public class EntityPersistenceNamingStrategy {
    * @param sourceName Name of the source to extract information from, e.g. file name or SQL table
    *     name
    * @return Meta information form individual time series source name
-   * @deprecated since 3.0. Use {@link #getIndividualTimesSeriesMetaInformation(String)} instead
+   * @deprecated since 3.0. Use {@link #individualTimesSeriesMetaInformation(String)} instead
    */
   @Deprecated(since = "3.0", forRemoval = true)
   public edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation
@@ -159,7 +159,7 @@ public class EntityPersistenceNamingStrategy {
    *     name
    * @return Meta information form individual time series source name
    */
-  public IndividualTimeSeriesMetaInformation getIndividualTimesSeriesMetaInformation(
+  public IndividualTimeSeriesMetaInformation individualTimesSeriesMetaInformation(
       String sourceName) {
     Matcher matcher = getIndividualTimeSeriesPattern().matcher(sourceName);
     if (!matcher.matches())
@@ -183,7 +183,7 @@ public class EntityPersistenceNamingStrategy {
    *
    * @param fileName File name to extract information from
    * @return Meta information form load profile time series file name
-   * @deprecated since 3.0. Use {@link #getLoadProfileTimesSeriesMetaInformation(String)} instead
+   * @deprecated since 3.0. Use {@link #loadProfileTimesSeriesMetaInformation(String)} instead
    */
   @Deprecated(since = "3.0", forRemoval = true)
   public edu.ie3.datamodel.io.csv.timeseries.LoadProfileTimeSeriesMetaInformation
@@ -203,7 +203,7 @@ public class EntityPersistenceNamingStrategy {
    * @param fileName File name to extract information from
    * @return Meta information form load profile time series file name
    */
-  public LoadProfileTimeSeriesMetaInformation getLoadProfileTimesSeriesMetaInformation(
+  public LoadProfileTimeSeriesMetaInformation loadProfileTimesSeriesMetaInformation(
       String fileName) {
     Matcher matcher = getLoadProfileTimeSeriesPattern().matcher(fileName);
     if (!matcher.matches())

--- a/src/main/java/edu/ie3/datamodel/io/naming/FileNamingStrategy.java
+++ b/src/main/java/edu/ie3/datamodel/io/naming/FileNamingStrategy.java
@@ -277,10 +277,9 @@ public class FileNamingStrategy {
     String withoutEnding = fileName.replaceAll("(?:\\.[^\\\\/\\s]{1,255}){1,2}$", "");
 
     if (getIndividualTimeSeriesPattern().matcher(withoutEnding).matches())
-      return entityPersistenceNamingStrategy.getIndividualTimesSeriesMetaInformation(withoutEnding);
+      return entityPersistenceNamingStrategy.individualTimesSeriesMetaInformation(withoutEnding);
     else if (getLoadProfileTimeSeriesPattern().matcher(withoutEnding).matches())
-      return entityPersistenceNamingStrategy.getLoadProfileTimesSeriesMetaInformation(
-          withoutEnding);
+      return entityPersistenceNamingStrategy.loadProfileTimesSeriesMetaInformation(withoutEnding);
     else
       throw new IllegalArgumentException(
           "Unknown format of '" + fileName + "'. Cannot extract meta information.");

--- a/src/main/java/edu/ie3/datamodel/io/naming/FileNamingStrategy.java
+++ b/src/main/java/edu/ie3/datamodel/io/naming/FileNamingStrategy.java
@@ -122,7 +122,7 @@ public class FileNamingStrategy {
    */
   public Optional<String> getDirectoryPath(Class<? extends UniqueEntity> cls) {
     Optional<String> maybeDirectoryName = fileHierarchy.getSubDirectory(cls);
-    if (!maybeDirectoryName.isPresent()) {
+    if (maybeDirectoryName.isEmpty()) {
       logger.debug("Cannot determine directory name for class '{}'.", cls);
       return Optional.empty();
     } else {
@@ -149,7 +149,7 @@ public class FileNamingStrategy {
   public <T extends TimeSeries<E, V>, E extends TimeSeriesEntry<V>, V extends Value>
       Optional<String> getDirectoryPath(T timeSeries) {
     Optional<String> maybeDirectoryName = fileHierarchy.getSubDirectory(timeSeries.getClass());
-    if (!maybeDirectoryName.isPresent()) {
+    if (maybeDirectoryName.isEmpty()) {
       logger.debug("Cannot determine directory name for time series '{}'.", timeSeries);
       return Optional.empty();
     } else {
@@ -218,7 +218,8 @@ public class FileNamingStrategy {
    * Extracts meta information from a file name, of a time series.
    *
    * @param path Path to the file
-   * @return The meeting meta information // todo deprecated notice
+   * @return The meeting meta information
+   * @deprecated since 3.0. Use {@link #timeSeriesMetaInformation(Path)} instead.
    */
   @Deprecated
   public FileNameMetaInformation extractTimeSeriesMetaInformation(Path path) {
@@ -235,7 +236,7 @@ public class FileNamingStrategy {
    * @param path Path to the file
    * @return The meeting meta information
    */
-  public DataSourceMetaInformation timeSeriesMetaInformation(Path path) {
+  public TimeSeriesMetaInformation timeSeriesMetaInformation(Path path) {
     /* Extract file name from possibly fully qualified path */
     Path fileName = path.getFileName();
     if (fileName == null)
@@ -248,12 +249,13 @@ public class FileNamingStrategy {
    * leading path has to be provided
    *
    * @param fileName File name
-   * @return The meeting meta information // todo deprecated notice
+   * @return The meeting meta information
+   * @deprecated since 3.0. Use {@link #timeSeriesMetaInformation(String)} instead.
    */
   @Deprecated
   public FileNameMetaInformation extractTimeSeriesMetaInformation(String fileName) {
 
-    DataSourceMetaInformation meta = timeSeriesMetaInformation(fileName);
+    TimeSeriesMetaInformation meta = timeSeriesMetaInformation(fileName);
     if (meta instanceof IndividualTimeSeriesMetaInformation ind) {
       return new edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation(ind);
     } else if (meta instanceof LoadProfileTimeSeriesMetaInformation load) {
@@ -270,7 +272,7 @@ public class FileNamingStrategy {
    * @param fileName File name
    * @return The meeting meta information
    */
-  public DataSourceMetaInformation timeSeriesMetaInformation(String fileName) {
+  public TimeSeriesMetaInformation timeSeriesMetaInformation(String fileName) {
     /* Remove the file ending (ending limited to 255 chars, which is the max file name allowed in NTFS and ext4) */
     String withoutEnding = fileName.replaceAll("(?:\\.[^\\\\/\\s]{1,255}){1,2}$", "");
 

--- a/src/main/java/edu/ie3/datamodel/io/naming/FileNamingStrategy.java
+++ b/src/main/java/edu/ie3/datamodel/io/naming/FileNamingStrategy.java
@@ -221,7 +221,7 @@ public class FileNamingStrategy {
    * @return The meeting meta information
    * @deprecated since 3.0. Use {@link #timeSeriesMetaInformation(Path)} instead.
    */
-  @Deprecated
+  @Deprecated(since = "3.0", forRemoval = true)
   public FileNameMetaInformation extractTimeSeriesMetaInformation(Path path) {
     /* Extract file name from possibly fully qualified path */
     Path fileName = path.getFileName();
@@ -252,7 +252,7 @@ public class FileNamingStrategy {
    * @return The meeting meta information
    * @deprecated since 3.0. Use {@link #timeSeriesMetaInformation(String)} instead.
    */
-  @Deprecated
+  @Deprecated(since = "3.0", forRemoval = true)
   public FileNameMetaInformation extractTimeSeriesMetaInformation(String fileName) {
 
     TimeSeriesMetaInformation meta = timeSeriesMetaInformation(fileName);

--- a/src/main/java/edu/ie3/datamodel/io/naming/TimeSeriesMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/naming/TimeSeriesMetaInformation.java
@@ -9,10 +9,10 @@ import java.util.Objects;
 import java.util.UUID;
 
 /** Meta information, that describe a certain data source */
-public abstract class DataSourceMetaInformation {
+public abstract class TimeSeriesMetaInformation {
   private final UUID uuid;
 
-  protected DataSourceMetaInformation(UUID uuid) {
+  protected TimeSeriesMetaInformation(UUID uuid) {
     this.uuid = uuid;
   }
 
@@ -23,7 +23,7 @@ public abstract class DataSourceMetaInformation {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof DataSourceMetaInformation that)) return false;
+    if (!(o instanceof TimeSeriesMetaInformation that)) return false;
     return uuid.equals(that.uuid);
   }
 
@@ -34,6 +34,6 @@ public abstract class DataSourceMetaInformation {
 
   @Override
   public String toString() {
-    return "DataSourceMetaInformation{" + "uuid=" + uuid + '}';
+    return "TimeSeriesMetaInformation{" + "uuid=" + uuid + '}';
   }
 }

--- a/src/main/java/edu/ie3/datamodel/io/naming/timeseries/ColumnScheme.java
+++ b/src/main/java/edu/ie3/datamodel/io/naming/timeseries/ColumnScheme.java
@@ -3,7 +3,7 @@
  * Institute of Energy Systems, Energy Efficiency and Energy Economics,
  * Research group Distribution grid planning and operation
 */
-package edu.ie3.datamodel.io.csv.timeseries;
+package edu.ie3.datamodel.io.naming.timeseries;
 
 import edu.ie3.datamodel.models.value.*;
 import edu.ie3.util.StringUtils;
@@ -12,8 +12,6 @@ import java.util.Objects;
 import java.util.Optional;
 
 /** Yet supported column schemes in individual time series */
-// todo JH javadoc
-@Deprecated
 public enum ColumnScheme {
   ENERGY_PRICE("c", EnergyPriceValue.class),
   ACTIVE_POWER("p", PValue.class),
@@ -26,7 +24,6 @@ public enum ColumnScheme {
   private final String scheme;
   private final Class<? extends Value> valueClass;
 
-  @Deprecated
   ColumnScheme(String scheme, Class<? extends Value> valueClass) {
     this.scheme = scheme;
     this.valueClass = valueClass;

--- a/src/main/java/edu/ie3/datamodel/io/naming/timeseries/ColumnScheme.java
+++ b/src/main/java/edu/ie3/datamodel/io/naming/timeseries/ColumnScheme.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
 
-/** Yet supported column schemes in individual time series */
+/** Supported column schemes in individual time series */
 public enum ColumnScheme {
   ENERGY_PRICE("c", EnergyPriceValue.class),
   ACTIVE_POWER("p", PValue.class),

--- a/src/main/java/edu/ie3/datamodel/io/naming/timeseries/IndividualTimeSeriesMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/naming/timeseries/IndividualTimeSeriesMetaInformation.java
@@ -1,0 +1,47 @@
+/*
+ * © 2021. TU Dortmund University,
+ * Institute of Energy Systems, Energy Efficiency and Energy Economics,
+ * Research group Distribution grid planning and operation
+*/
+package edu.ie3.datamodel.io.naming.timeseries;
+
+import edu.ie3.datamodel.io.naming.DataSourceMetaInformation;
+import java.util.Objects;
+import java.util.UUID;
+
+/** Specific meta information, that can be derived from an individual time series file */
+public class IndividualTimeSeriesMetaInformation extends DataSourceMetaInformation {
+  private final ColumnScheme columnScheme;
+
+  public IndividualTimeSeriesMetaInformation(UUID uuid, ColumnScheme columnScheme) {
+    super(uuid);
+    this.columnScheme = columnScheme;
+  }
+
+  public ColumnScheme getColumnScheme() {
+    return columnScheme;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof IndividualTimeSeriesMetaInformation that)) return false;
+    if (!super.equals(o)) return false;
+    return columnScheme == that.columnScheme;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), columnScheme);
+  }
+
+  @Override
+  public String toString() {
+    return "IndividualTimeSeriesMetaInformation{"
+        + "uuid="
+        + getUuid()
+        + ", columnScheme="
+        + columnScheme
+        + '}';
+  }
+}

--- a/src/main/java/edu/ie3/datamodel/io/naming/timeseries/IndividualTimeSeriesMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/naming/timeseries/IndividualTimeSeriesMetaInformation.java
@@ -5,12 +5,12 @@
 */
 package edu.ie3.datamodel.io.naming.timeseries;
 
-import edu.ie3.datamodel.io.naming.DataSourceMetaInformation;
+import edu.ie3.datamodel.io.naming.TimeSeriesMetaInformation;
 import java.util.Objects;
 import java.util.UUID;
 
 /** Specific meta information, that can be derived from an individual time series file */
-public class IndividualTimeSeriesMetaInformation extends DataSourceMetaInformation {
+public class IndividualTimeSeriesMetaInformation extends TimeSeriesMetaInformation {
   private final ColumnScheme columnScheme;
 
   public IndividualTimeSeriesMetaInformation(UUID uuid, ColumnScheme columnScheme) {

--- a/src/main/java/edu/ie3/datamodel/io/naming/timeseries/LoadProfileTimeSeriesMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/naming/timeseries/LoadProfileTimeSeriesMetaInformation.java
@@ -3,31 +3,19 @@
  * Institute of Energy Systems, Energy Efficiency and Energy Economics,
  * Research group Distribution grid planning and operation
 */
-package edu.ie3.datamodel.io.csv.timeseries;
+package edu.ie3.datamodel.io.naming.timeseries;
 
-import edu.ie3.datamodel.io.csv.FileNameMetaInformation;
+import edu.ie3.datamodel.io.naming.DataSourceMetaInformation;
 import java.util.Objects;
 import java.util.UUID;
 
-/**
- * Specific meta information, that can be derived from a load profile time series file
- *
- * @deprecated since 3.0. Use {@link
- *     edu.ie3.datamodel.io.naming.LoadProfileTimeSeriesMetaInformation} instead
- */
-@Deprecated
-public class LoadProfileTimeSeriesMetaInformation extends FileNameMetaInformation {
+/** Specific meta information, that can be derived from a load profile time series file */
+public class LoadProfileTimeSeriesMetaInformation extends DataSourceMetaInformation {
   private final String profile;
 
   public LoadProfileTimeSeriesMetaInformation(UUID uuid, String profile) {
     super(uuid);
     this.profile = profile;
-  }
-
-  public LoadProfileTimeSeriesMetaInformation(
-      edu.ie3.datamodel.io.naming.timeseries.LoadProfileTimeSeriesMetaInformation metaInformation) {
-    super(metaInformation.getUuid());
-    this.profile = metaInformation.getProfile();
   }
 
   public String getProfile() {
@@ -37,9 +25,8 @@ public class LoadProfileTimeSeriesMetaInformation extends FileNameMetaInformatio
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof LoadProfileTimeSeriesMetaInformation)) return false;
+    if (!(o instanceof LoadProfileTimeSeriesMetaInformation that)) return false;
     if (!super.equals(o)) return false;
-    LoadProfileTimeSeriesMetaInformation that = (LoadProfileTimeSeriesMetaInformation) o;
     return profile.equals(that.profile);
   }
 

--- a/src/main/java/edu/ie3/datamodel/io/naming/timeseries/LoadProfileTimeSeriesMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/naming/timeseries/LoadProfileTimeSeriesMetaInformation.java
@@ -5,12 +5,12 @@
 */
 package edu.ie3.datamodel.io.naming.timeseries;
 
-import edu.ie3.datamodel.io.naming.DataSourceMetaInformation;
+import edu.ie3.datamodel.io.naming.TimeSeriesMetaInformation;
 import java.util.Objects;
 import java.util.UUID;
 
 /** Specific meta information, that can be derived from a load profile time series file */
-public class LoadProfileTimeSeriesMetaInformation extends DataSourceMetaInformation {
+public class LoadProfileTimeSeriesMetaInformation extends TimeSeriesMetaInformation {
   private final String profile;
 
   public LoadProfileTimeSeriesMetaInformation(UUID uuid, String profile) {

--- a/src/main/java/edu/ie3/datamodel/io/source/TimeSeriesMappingSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/TimeSeriesMappingSource.java
@@ -5,7 +5,7 @@
 */
 package edu.ie3.datamodel.io.source;
 
-import edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation;
+import edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation;
 import edu.ie3.datamodel.models.input.InputEntity;
 import java.util.Map;
 import java.util.Objects;
@@ -39,8 +39,19 @@ public interface TimeSeriesMappingSource extends DataSource {
    *
    * @param timeSeriesUuid Unique identifier of the time series in question
    * @return An Option onto the meta information
+   * @deprecated since 3.0. Use {@link #timeSeriesMetaInformation(java.util.UUID)} instead
    */
-  Optional<IndividualTimeSeriesMetaInformation> getTimeSeriesMetaInformation(UUID timeSeriesUuid);
+  @Deprecated
+  Optional<edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation>
+      getTimeSeriesMetaInformation(UUID timeSeriesUuid);
+
+  /**
+   * Get an option on the given time series meta information
+   *
+   * @param timeSeriesUuid Unique identifier of the time series in question
+   * @return An Option onto the meta information
+   */
+  Optional<IndividualTimeSeriesMetaInformation> timeSeriesMetaInformation(UUID timeSeriesUuid);
 
   /** Class to represent one entry within the participant to time series mapping */
   class MappingEntry extends InputEntity {

--- a/src/main/java/edu/ie3/datamodel/io/source/TimeSeriesMappingSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/TimeSeriesMappingSource.java
@@ -41,7 +41,7 @@ public interface TimeSeriesMappingSource extends DataSource {
    * @return An Option onto the meta information
    * @deprecated since 3.0. Use {@link #timeSeriesMetaInformation(java.util.UUID)} instead
    */
-  @Deprecated
+  @Deprecated(since = "3.0", forRemoval = true)
   Optional<edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation>
       getTimeSeriesMetaInformation(UUID timeSeriesUuid);
 

--- a/src/main/java/edu/ie3/datamodel/io/source/TimeSeriesSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/TimeSeriesSource.java
@@ -5,9 +5,9 @@
 */
 package edu.ie3.datamodel.io.source;
 
-import static edu.ie3.datamodel.io.csv.timeseries.ColumnScheme.*;
+import static edu.ie3.datamodel.io.naming.timeseries.ColumnScheme.*;
 
-import edu.ie3.datamodel.io.csv.timeseries.ColumnScheme;
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme;
 import edu.ie3.datamodel.models.timeseries.individual.IndividualTimeSeries;
 import edu.ie3.datamodel.models.value.Value;
 import edu.ie3.util.interval.ClosedInterval;
@@ -20,6 +20,25 @@ import java.util.Optional;
  * model
  */
 public interface TimeSeriesSource<V extends Value> extends DataSource {
+
+  /**
+   * Checks whether the given column scheme can be used with time series.
+   *
+   * @param scheme the column scheme to check
+   * @return whether the scheme is accepted or not
+   * @deprecated since 3.0
+   */
+  @Deprecated
+  static boolean isSchemeAccepted(edu.ie3.datamodel.io.csv.timeseries.ColumnScheme scheme) {
+    return EnumSet.of(
+            edu.ie3.datamodel.io.csv.timeseries.ColumnScheme.ACTIVE_POWER,
+            edu.ie3.datamodel.io.csv.timeseries.ColumnScheme.APPARENT_POWER,
+            edu.ie3.datamodel.io.csv.timeseries.ColumnScheme.ENERGY_PRICE,
+            edu.ie3.datamodel.io.csv.timeseries.ColumnScheme.APPARENT_POWER_AND_HEAT_DEMAND,
+            edu.ie3.datamodel.io.csv.timeseries.ColumnScheme.ACTIVE_POWER_AND_HEAT_DEMAND,
+            edu.ie3.datamodel.io.csv.timeseries.ColumnScheme.HEAT_DEMAND)
+        .contains(scheme);
+  }
 
   /**
    * Checks whether the given column scheme can be used with time series.

--- a/src/main/java/edu/ie3/datamodel/io/source/TimeSeriesSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/TimeSeriesSource.java
@@ -28,7 +28,7 @@ public interface TimeSeriesSource<V extends Value> extends DataSource {
    * @return whether the scheme is accepted or not
    * @deprecated since 3.0
    */
-  @Deprecated
+  @Deprecated(since = "3.0", forRemoval = true)
   static boolean isSchemeAccepted(edu.ie3.datamodel.io.csv.timeseries.ColumnScheme scheme) {
     return EnumSet.of(
             edu.ie3.datamodel.io.csv.timeseries.ColumnScheme.ACTIVE_POWER,

--- a/src/main/java/edu/ie3/datamodel/io/source/TimeSeriesSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/TimeSeriesSource.java
@@ -26,7 +26,8 @@ public interface TimeSeriesSource<V extends Value> extends DataSource {
    *
    * @param scheme the column scheme to check
    * @return whether the scheme is accepted or not
-   * @deprecated since 3.0
+   * @deprecated since 3.0. Use {@link
+   *     #isSchemeAccepted(edu.ie3.datamodel.io.naming.timeseries.ColumnScheme)} instead.
    */
   @Deprecated(since = "3.0", forRemoval = true)
   static boolean isSchemeAccepted(edu.ie3.datamodel.io.csv.timeseries.ColumnScheme scheme) {

--- a/src/main/java/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesMappingSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesMappingSource.java
@@ -45,7 +45,7 @@ public class CsvTimeSeriesMappingSource extends CsvDataSource implements TimeSer
 
   /** @deprecated since 3.0. Use {@link #timeSeriesMetaInformation(java.util.UUID)} instead */
   @Override
-  @Deprecated
+  @Deprecated(since = "3.0", forRemoval = true)
   public Optional<edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation>
       getTimeSeriesMetaInformation(UUID timeSeriesUuid) {
     return connector.getIndividualTimeSeriesMetaInformation(timeSeriesUuid);

--- a/src/main/java/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesMappingSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesMappingSource.java
@@ -5,10 +5,10 @@
 */
 package edu.ie3.datamodel.io.source.csv;
 
-import edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation;
 import edu.ie3.datamodel.io.factory.SimpleEntityData;
 import edu.ie3.datamodel.io.factory.timeseries.TimeSeriesMappingFactory;
 import edu.ie3.datamodel.io.naming.FileNamingStrategy;
+import edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation;
 import edu.ie3.datamodel.io.source.TimeSeriesMappingSource;
 import java.util.Map;
 import java.util.Optional;
@@ -43,9 +43,17 @@ public class CsvTimeSeriesMappingSource extends CsvDataSource implements TimeSer
     return mapping;
   }
 
+  /** @deprecated since 3.0. Use {@link #timeSeriesMetaInformation(java.util.UUID)} instead */
   @Override
-  public Optional<IndividualTimeSeriesMetaInformation> getTimeSeriesMetaInformation(
-      UUID timeSeriesUuid) {
+  @Deprecated
+  public Optional<edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation>
+      getTimeSeriesMetaInformation(UUID timeSeriesUuid) {
     return connector.getIndividualTimeSeriesMetaInformation(timeSeriesUuid);
+  }
+
+  @Override
+  public Optional<IndividualTimeSeriesMetaInformation> timeSeriesMetaInformation(
+      UUID timeSeriesUuid) {
+    return connector.individualTimeSeriesMetaInformation(timeSeriesUuid);
   }
 }

--- a/src/main/java/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesSource.java
@@ -37,7 +37,9 @@ public class CsvTimeSeriesSource<V extends Value> extends CsvDataSource
    * @param metaInformation The given meta information
    * @throws SourceException If the given meta information are not supported
    * @return The source
-   * @deprecated since 3.0
+   * @deprecated since 3.0. Use {@link CsvTimeSeriesSource#getSource(java.lang.String,
+   *     java.lang.String, edu.ie3.datamodel.io.naming.FileNamingStrategy,
+   *     edu.ie3.datamodel.io.csv.CsvIndividualTimeSeriesMetaInformation)} instead.
    */
   @Deprecated(since = "3.0", forRemoval = true)
   public static CsvTimeSeriesSource<? extends Value> getSource(

--- a/src/main/java/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesSource.java
@@ -39,7 +39,7 @@ public class CsvTimeSeriesSource<V extends Value> extends CsvDataSource
    * @return The source
    * @deprecated since 3.0
    */
-  @Deprecated
+  @Deprecated(since = "3.0", forRemoval = true)
   public static CsvTimeSeriesSource<? extends Value> getSource(
       String csvSep,
       String folderPath,
@@ -57,7 +57,7 @@ public class CsvTimeSeriesSource<V extends Value> extends CsvDataSource
   }
 
   /** @deprecated since 3.0 */
-  @Deprecated
+  @Deprecated(since = "3.0", forRemoval = true)
   private static <T extends Value> CsvTimeSeriesSource<T> create(
       String csvSep,
       String folderPath,

--- a/src/main/java/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesSource.java
@@ -6,7 +6,7 @@
 package edu.ie3.datamodel.io.source.csv;
 
 import edu.ie3.datamodel.exceptions.SourceException;
-import edu.ie3.datamodel.io.connectors.CsvFileConnector;
+import edu.ie3.datamodel.io.csv.CsvIndividualTimeSeriesMetaInformation;
 import edu.ie3.datamodel.io.factory.timeseries.*;
 import edu.ie3.datamodel.io.naming.FileNamingStrategy;
 import edu.ie3.datamodel.io.source.TimeSeriesSource;
@@ -37,12 +37,60 @@ public class CsvTimeSeriesSource<V extends Value> extends CsvDataSource
    * @param metaInformation The given meta information
    * @throws SourceException If the given meta information are not supported
    * @return The source
+   * @deprecated since 3.0
+   */
+  @Deprecated
+  public static CsvTimeSeriesSource<? extends Value> getSource(
+      String csvSep,
+      String folderPath,
+      FileNamingStrategy fileNamingStrategy,
+      edu.ie3.datamodel.io.connectors.CsvFileConnector.CsvIndividualTimeSeriesMetaInformation
+          metaInformation)
+      throws SourceException {
+    if (!TimeSeriesSource.isSchemeAccepted(metaInformation.getColumnScheme()))
+      throw new SourceException(
+          "Unsupported column scheme '" + metaInformation.getColumnScheme() + "'.");
+
+    Class<? extends Value> valClass = metaInformation.getColumnScheme().getValueClass();
+
+    return create(csvSep, folderPath, fileNamingStrategy, metaInformation, valClass);
+  }
+
+  /** @deprecated since 3.0 */
+  @Deprecated
+  private static <T extends Value> CsvTimeSeriesSource<T> create(
+      String csvSep,
+      String folderPath,
+      FileNamingStrategy fileNamingStrategy,
+      edu.ie3.datamodel.io.connectors.CsvFileConnector.CsvIndividualTimeSeriesMetaInformation
+          metaInformation,
+      Class<T> valClass) {
+    TimeBasedSimpleValueFactory<T> valueFactory = new TimeBasedSimpleValueFactory<>(valClass);
+    return new CsvTimeSeriesSource<>(
+        csvSep,
+        folderPath,
+        fileNamingStrategy,
+        metaInformation.getUuid(),
+        metaInformation.getFullFilePath(),
+        valClass,
+        valueFactory);
+  }
+
+  /**
+   * Factory method to build a source from given meta information
+   *
+   * @param csvSep the separator string for csv columns
+   * @param folderPath path to the folder holding the time series files
+   * @param fileNamingStrategy strategy for the file naming of time series files / data sinks
+   * @param metaInformation The given meta information
+   * @throws SourceException If the given meta information are not supported
+   * @return The source
    */
   public static CsvTimeSeriesSource<? extends Value> getSource(
       String csvSep,
       String folderPath,
       FileNamingStrategy fileNamingStrategy,
-      CsvFileConnector.CsvIndividualTimeSeriesMetaInformation metaInformation)
+      CsvIndividualTimeSeriesMetaInformation metaInformation)
       throws SourceException {
     if (!TimeSeriesSource.isSchemeAccepted(metaInformation.getColumnScheme()))
       throw new SourceException(
@@ -57,7 +105,7 @@ public class CsvTimeSeriesSource<V extends Value> extends CsvDataSource
       String csvSep,
       String folderPath,
       FileNamingStrategy fileNamingStrategy,
-      CsvFileConnector.CsvIndividualTimeSeriesMetaInformation metaInformation,
+      CsvIndividualTimeSeriesMetaInformation metaInformation,
       Class<T> valClass) {
     TimeBasedSimpleValueFactory<T> valueFactory = new TimeBasedSimpleValueFactory<>(valClass);
     return new CsvTimeSeriesSource<>(

--- a/src/main/java/edu/ie3/datamodel/io/source/csv/CsvWeatherSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/csv/CsvWeatherSource.java
@@ -6,11 +6,12 @@
 package edu.ie3.datamodel.io.source.csv;
 
 import edu.ie3.datamodel.io.connectors.CsvFileConnector;
-import edu.ie3.datamodel.io.csv.timeseries.ColumnScheme;
+import edu.ie3.datamodel.io.csv.CsvIndividualTimeSeriesMetaInformation;
 import edu.ie3.datamodel.io.factory.timeseries.IdCoordinateFactory;
 import edu.ie3.datamodel.io.factory.timeseries.TimeBasedWeatherValueData;
 import edu.ie3.datamodel.io.factory.timeseries.TimeBasedWeatherValueFactory;
 import edu.ie3.datamodel.io.naming.FileNamingStrategy;
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme;
 import edu.ie3.datamodel.io.source.IdCoordinateSource;
 import edu.ie3.datamodel.io.source.WeatherSource;
 import edu.ie3.datamodel.models.UniqueEntity;
@@ -94,12 +95,11 @@ public class CsvWeatherSource extends CsvDataSource implements WeatherSource {
    */
   private Map<Point, IndividualTimeSeries<WeatherValue>> getWeatherTimeSeries() {
     /* Get only weather time series meta information */
-    Map<ColumnScheme, Set<CsvFileConnector.CsvIndividualTimeSeriesMetaInformation>>
-        colTypeToMetaData =
-            connector.getCsvIndividualTimeSeriesMetaInformation(ColumnScheme.WEATHER);
+    Map<ColumnScheme, Set<CsvIndividualTimeSeriesMetaInformation>> colTypeToMetaData =
+        connector.getCsvIndividualTimeSeriesMetaInformation(ColumnScheme.WEATHER);
 
     /* Reading in weather time series */
-    Set<CsvFileConnector.CsvIndividualTimeSeriesMetaInformation> weatherCsvMetaInformation =
+    Set<CsvIndividualTimeSeriesMetaInformation> weatherCsvMetaInformation =
         colTypeToMetaData.get(ColumnScheme.WEATHER);
 
     return readWeatherTimeSeries(weatherCsvMetaInformation, connector);
@@ -154,13 +154,13 @@ public class CsvWeatherSource extends CsvDataSource implements WeatherSource {
    * @return time series mapped to the represented coordinate
    */
   private Map<Point, IndividualTimeSeries<WeatherValue>> readWeatherTimeSeries(
-      Set<CsvFileConnector.CsvIndividualTimeSeriesMetaInformation> weatherMetaInformation,
+      Set<CsvIndividualTimeSeriesMetaInformation> weatherMetaInformation,
       CsvFileConnector connector) {
     final Map<Point, IndividualTimeSeries<WeatherValue>> weatherTimeSeries = new HashMap<>();
     Function<Map<String, String>, Optional<TimeBasedValue<WeatherValue>>> fieldToValueFunction =
         this::buildWeatherValue;
     /* Reading in weather time series */
-    for (CsvFileConnector.CsvIndividualTimeSeriesMetaInformation data : weatherMetaInformation) {
+    for (CsvIndividualTimeSeriesMetaInformation data : weatherMetaInformation) {
       // we need a reader for each file
       try (BufferedReader reader = connector.initReader(data.getFullFilePath())) {
         filterEmptyOptionals(

--- a/src/main/java/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesMappingSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesMappingSource.java
@@ -6,10 +6,10 @@
 package edu.ie3.datamodel.io.source.sql;
 
 import edu.ie3.datamodel.io.connectors.SqlConnector;
-import edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation;
 import edu.ie3.datamodel.io.factory.SimpleEntityData;
 import edu.ie3.datamodel.io.factory.timeseries.TimeSeriesMappingFactory;
 import edu.ie3.datamodel.io.naming.EntityPersistenceNamingStrategy;
+import edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation;
 import edu.ie3.datamodel.io.source.TimeSeriesMappingSource;
 import java.util.Map;
 import java.util.Optional;
@@ -43,11 +43,20 @@ public class SqlTimeSeriesMappingSource extends SqlDataSource<TimeSeriesMappingS
         .collect(Collectors.toMap(MappingEntry::getParticipant, MappingEntry::getTimeSeries));
   }
 
+  /** @deprecated since 3.0. Use {@link #timeSeriesMetaInformation(java.util.UUID)} instead */
   @Override
-  public Optional<IndividualTimeSeriesMetaInformation> getTimeSeriesMetaInformation(
-      UUID timeSeriesUuid) {
+  @Deprecated
+  public Optional<edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation>
+      getTimeSeriesMetaInformation(UUID timeSeriesUuid) {
     return getDbTableName(null, "%" + timeSeriesUuid.toString())
         .map(entityPersistenceNamingStrategy::extractIndividualTimesSeriesMetaInformation);
+  }
+
+  @Override
+  public Optional<IndividualTimeSeriesMetaInformation> timeSeriesMetaInformation(
+      UUID timeSeriesUuid) {
+    return getDbTableName(null, "%" + timeSeriesUuid.toString())
+        .map(entityPersistenceNamingStrategy::getIndividualTimesSeriesMetaInformation);
   }
 
   @Override

--- a/src/main/java/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesMappingSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesMappingSource.java
@@ -52,7 +52,7 @@ public class SqlTimeSeriesMappingSource extends SqlDataSource<TimeSeriesMappingS
   @Deprecated(since = "3.0", forRemoval = true)
   public Optional<edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation>
       getTimeSeriesMetaInformation(UUID timeSeriesUuid) {
-    return getDbTableName(null, "%" + timeSeriesUuid.toString())
+    return getDbTableName(schemaName, "%" + timeSeriesUuid.toString())
         .map(entityPersistenceNamingStrategy::extractIndividualTimesSeriesMetaInformation);
   }
 
@@ -63,8 +63,7 @@ public class SqlTimeSeriesMappingSource extends SqlDataSource<TimeSeriesMappingS
         .map(
             tableName -> {
               IndividualTimeSeriesMetaInformation metaInformation =
-                  entityPersistenceNamingStrategy.getIndividualTimesSeriesMetaInformation(
-                      tableName);
+                  entityPersistenceNamingStrategy.individualTimesSeriesMetaInformation(tableName);
               return new SqlIndividualTimeSeriesMetaInformation(metaInformation, tableName);
             });
   }

--- a/src/main/java/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesMappingSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesMappingSource.java
@@ -45,7 +45,7 @@ public class SqlTimeSeriesMappingSource extends SqlDataSource<TimeSeriesMappingS
 
   /** @deprecated since 3.0. Use {@link #timeSeriesMetaInformation(java.util.UUID)} instead */
   @Override
-  @Deprecated
+  @Deprecated(since = "3.0", forRemoval = true)
   public Optional<edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation>
       getTimeSeriesMetaInformation(UUID timeSeriesUuid) {
     return getDbTableName(null, "%" + timeSeriesUuid.toString())

--- a/src/main/java/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesSource.java
@@ -7,9 +7,9 @@ package edu.ie3.datamodel.io.source.sql;
 
 import edu.ie3.datamodel.exceptions.SourceException;
 import edu.ie3.datamodel.io.connectors.SqlConnector;
-import edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation;
 import edu.ie3.datamodel.io.factory.timeseries.SimpleTimeBasedValueData;
 import edu.ie3.datamodel.io.factory.timeseries.TimeBasedSimpleValueFactory;
+import edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation;
 import edu.ie3.datamodel.io.source.TimeSeriesSource;
 import edu.ie3.datamodel.models.timeseries.individual.IndividualTimeSeries;
 import edu.ie3.datamodel.models.timeseries.individual.TimeBasedValue;
@@ -35,6 +35,36 @@ public class SqlTimeSeriesSource<V extends Value> extends SqlDataSource<TimeBase
 
   private final String queryTimeInterval;
   private final String queryTime;
+
+  /**
+   * Factory method to build a source from given meta information
+   *
+   * @param connector the connector needed for database connection
+   * @param schemaName the database schema to use
+   * @param tableName the database table to use
+   * @param metaInformation the time series meta information
+   * @param timePattern the pattern of time values
+   * @return a SqlTimeSeriesSource for given time series table
+   * @throws SourceException if the column scheme is not supported
+   * @deprecated since 3.0
+   */
+  @Deprecated
+  public static SqlTimeSeriesSource<? extends Value> getSource(
+      SqlConnector connector,
+      String schemaName,
+      String tableName,
+      edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation metaInformation,
+      String timePattern)
+      throws SourceException {
+    if (!TimeSeriesSource.isSchemeAccepted(metaInformation.getColumnScheme()))
+      throw new SourceException(
+          "Unsupported column scheme '" + metaInformation.getColumnScheme() + "'.");
+
+    Class<? extends Value> valClass = metaInformation.getColumnScheme().getValueClass();
+
+    return create(
+        connector, schemaName, tableName, metaInformation.getUuid(), valClass, timePattern);
+  }
 
   /**
    * Factory method to build a source from given meta information

--- a/src/main/java/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesSource.java
@@ -46,7 +46,9 @@ public class SqlTimeSeriesSource<V extends Value> extends SqlDataSource<TimeBase
    * @param timePattern the pattern of time values
    * @return a SqlTimeSeriesSource for given time series table
    * @throws SourceException if the column scheme is not supported
-   * @deprecated since 3.0
+   * @deprecated since 3.0. Use {@link #getSource(edu.ie3.datamodel.io.connectors.SqlConnector,
+   *     java.lang.String, edu.ie3.datamodel.io.sql.SqlIndividualTimeSeriesMetaInformation,
+   *     java.lang.String)} instead.
    */
   @Deprecated(since = "3.0", forRemoval = true)
   public static SqlTimeSeriesSource<? extends Value> getSource(

--- a/src/main/java/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesSource.java
@@ -9,8 +9,8 @@ import edu.ie3.datamodel.exceptions.SourceException;
 import edu.ie3.datamodel.io.connectors.SqlConnector;
 import edu.ie3.datamodel.io.factory.timeseries.SimpleTimeBasedValueData;
 import edu.ie3.datamodel.io.factory.timeseries.TimeBasedSimpleValueFactory;
-import edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation;
 import edu.ie3.datamodel.io.source.TimeSeriesSource;
+import edu.ie3.datamodel.io.sql.SqlIndividualTimeSeriesMetaInformation;
 import edu.ie3.datamodel.models.timeseries.individual.IndividualTimeSeries;
 import edu.ie3.datamodel.models.timeseries.individual.TimeBasedValue;
 import edu.ie3.datamodel.models.value.Value;
@@ -71,7 +71,6 @@ public class SqlTimeSeriesSource<V extends Value> extends SqlDataSource<TimeBase
    *
    * @param connector the connector needed for database connection
    * @param schemaName the database schema to use
-   * @param tableName the database table to use
    * @param metaInformation the time series meta information
    * @param timePattern the pattern of time values
    * @return a SqlTimeSeriesSource for given time series table
@@ -80,8 +79,7 @@ public class SqlTimeSeriesSource<V extends Value> extends SqlDataSource<TimeBase
   public static SqlTimeSeriesSource<? extends Value> getSource(
       SqlConnector connector,
       String schemaName,
-      String tableName,
-      IndividualTimeSeriesMetaInformation metaInformation,
+      SqlIndividualTimeSeriesMetaInformation metaInformation,
       String timePattern)
       throws SourceException {
     if (!TimeSeriesSource.isSchemeAccepted(metaInformation.getColumnScheme()))
@@ -91,7 +89,12 @@ public class SqlTimeSeriesSource<V extends Value> extends SqlDataSource<TimeBase
     Class<? extends Value> valClass = metaInformation.getColumnScheme().getValueClass();
 
     return create(
-        connector, schemaName, tableName, metaInformation.getUuid(), valClass, timePattern);
+        connector,
+        schemaName,
+        metaInformation.getTableName(),
+        metaInformation.getUuid(),
+        valClass,
+        timePattern);
   }
 
   private static <T extends Value> SqlTimeSeriesSource<T> create(

--- a/src/main/java/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesSource.java
@@ -48,7 +48,7 @@ public class SqlTimeSeriesSource<V extends Value> extends SqlDataSource<TimeBase
    * @throws SourceException if the column scheme is not supported
    * @deprecated since 3.0
    */
-  @Deprecated
+  @Deprecated(since = "3.0", forRemoval = true)
   public static SqlTimeSeriesSource<? extends Value> getSource(
       SqlConnector connector,
       String schemaName,

--- a/src/main/java/edu/ie3/datamodel/io/sql/SqlIndividualTimeSeriesMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/sql/SqlIndividualTimeSeriesMetaInformation.java
@@ -1,0 +1,60 @@
+/*
+ * © 2022. TU Dortmund University,
+ * Institute of Energy Systems, Energy Efficiency and Energy Economics,
+ * Research group Distribution grid planning and operation
+*/
+package edu.ie3.datamodel.io.sql;
+
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme;
+import edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Enhancing the {@link IndividualTimeSeriesMetaInformation} with the name of the table containing
+ * the time series
+ */
+public class SqlIndividualTimeSeriesMetaInformation extends IndividualTimeSeriesMetaInformation {
+  private final String tableName;
+
+  public SqlIndividualTimeSeriesMetaInformation(
+      UUID uuid, ColumnScheme columnScheme, String tableName) {
+    super(uuid, columnScheme);
+    this.tableName = tableName;
+  }
+
+  public SqlIndividualTimeSeriesMetaInformation(
+      IndividualTimeSeriesMetaInformation metaInformation, String fullFilePath) {
+    this(metaInformation.getUuid(), metaInformation.getColumnScheme(), fullFilePath);
+  }
+
+  public String getTableName() {
+    return tableName;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof SqlIndividualTimeSeriesMetaInformation that)) return false;
+    if (!super.equals(o)) return false;
+    return tableName.equals(that.tableName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), tableName);
+  }
+
+  @Override
+  public String toString() {
+    return "SqlIndividualTimeSeriesMetaInformation{"
+        + "uuid="
+        + getUuid()
+        + ", columnScheme="
+        + getColumnScheme()
+        + ", tableName='"
+        + tableName
+        + '\''
+        + '}';
+  }
+}

--- a/src/test/groovy/edu/ie3/datamodel/io/connectors/CsvFileConnectorTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/connectors/CsvFileConnectorTest.groovy
@@ -6,11 +6,12 @@
 package edu.ie3.datamodel.io.connectors
 
 import edu.ie3.datamodel.exceptions.ConnectorException
+import edu.ie3.datamodel.io.csv.CsvIndividualTimeSeriesMetaInformation
 import edu.ie3.datamodel.io.naming.FileNamingStrategy
 import edu.ie3.datamodel.io.csv.CsvFileDefinition
 import edu.ie3.datamodel.io.naming.DefaultDirectoryHierarchy
-import edu.ie3.datamodel.io.csv.timeseries.ColumnScheme
 import edu.ie3.datamodel.io.naming.EntityPersistenceNamingStrategy
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme
 import edu.ie3.datamodel.models.StandardUnits
 import edu.ie3.datamodel.models.input.NodeInput
 import edu.ie3.datamodel.models.timeseries.individual.IndividualTimeSeries
@@ -80,12 +81,12 @@ class CsvFileConnectorTest extends Specification {
 	def "The csv file connector is able to build correct uuid to meta information mapping"() {
 		given:
 		def expected = [
-			(UUID.fromString("53990eea-1b5d-47e8-9134-6d8de36604bf")): new CsvFileConnector.CsvIndividualTimeSeriesMetaInformation(UUID.fromString("53990eea-1b5d-47e8-9134-6d8de36604bf"), ColumnScheme.APPARENT_POWER, "its_pq_53990eea-1b5d-47e8-9134-6d8de36604bf"),
-			(UUID.fromString("fcf0b851-a836-4bde-8090-f44c382ed226")): new CsvFileConnector.CsvIndividualTimeSeriesMetaInformation(UUID.fromString("fcf0b851-a836-4bde-8090-f44c382ed226"), ColumnScheme.ACTIVE_POWER, "its_p_fcf0b851-a836-4bde-8090-f44c382ed226"),
-			(UUID.fromString("5022a70e-a58f-4bac-b8ec-1c62376c216b")): new CsvFileConnector.CsvIndividualTimeSeriesMetaInformation(UUID.fromString("5022a70e-a58f-4bac-b8ec-1c62376c216b"), ColumnScheme.APPARENT_POWER_AND_HEAT_DEMAND, "its_pqh_5022a70e-a58f-4bac-b8ec-1c62376c216b"),
-			(UUID.fromString("b88dee50-5484-4136-901d-050d8c1c97d1")): new CsvFileConnector.CsvIndividualTimeSeriesMetaInformation(UUID.fromString("b88dee50-5484-4136-901d-050d8c1c97d1"), ColumnScheme.ENERGY_PRICE, "its_c_b88dee50-5484-4136-901d-050d8c1c97d1"),
-			(UUID.fromString("c7b0d9d6-5044-4f51-80b4-f221d8b1f14b")): new CsvFileConnector.CsvIndividualTimeSeriesMetaInformation(UUID.fromString("c7b0d9d6-5044-4f51-80b4-f221d8b1f14b"), ColumnScheme.ENERGY_PRICE, "its_c_c7b0d9d6-5044-4f51-80b4-f221d8b1f14b"),
-			(UUID.fromString("085d98ee-09a2-4de4-b119-83949690d7b6")): new CsvFileConnector.CsvIndividualTimeSeriesMetaInformation(UUID.fromString("085d98ee-09a2-4de4-b119-83949690d7b6"), ColumnScheme.WEATHER, "its_weather_085d98ee-09a2-4de4-b119-83949690d7b6")
+			(UUID.fromString("53990eea-1b5d-47e8-9134-6d8de36604bf")): new CsvIndividualTimeSeriesMetaInformation(UUID.fromString("53990eea-1b5d-47e8-9134-6d8de36604bf"), ColumnScheme.APPARENT_POWER, "its_pq_53990eea-1b5d-47e8-9134-6d8de36604bf"),
+			(UUID.fromString("fcf0b851-a836-4bde-8090-f44c382ed226")): new CsvIndividualTimeSeriesMetaInformation(UUID.fromString("fcf0b851-a836-4bde-8090-f44c382ed226"), ColumnScheme.ACTIVE_POWER, "its_p_fcf0b851-a836-4bde-8090-f44c382ed226"),
+			(UUID.fromString("5022a70e-a58f-4bac-b8ec-1c62376c216b")): new CsvIndividualTimeSeriesMetaInformation(UUID.fromString("5022a70e-a58f-4bac-b8ec-1c62376c216b"), ColumnScheme.APPARENT_POWER_AND_HEAT_DEMAND, "its_pqh_5022a70e-a58f-4bac-b8ec-1c62376c216b"),
+			(UUID.fromString("b88dee50-5484-4136-901d-050d8c1c97d1")): new CsvIndividualTimeSeriesMetaInformation(UUID.fromString("b88dee50-5484-4136-901d-050d8c1c97d1"), ColumnScheme.ENERGY_PRICE, "its_c_b88dee50-5484-4136-901d-050d8c1c97d1"),
+			(UUID.fromString("c7b0d9d6-5044-4f51-80b4-f221d8b1f14b")): new CsvIndividualTimeSeriesMetaInformation(UUID.fromString("c7b0d9d6-5044-4f51-80b4-f221d8b1f14b"), ColumnScheme.ENERGY_PRICE, "its_c_c7b0d9d6-5044-4f51-80b4-f221d8b1f14b"),
+			(UUID.fromString("085d98ee-09a2-4de4-b119-83949690d7b6")): new CsvIndividualTimeSeriesMetaInformation(UUID.fromString("085d98ee-09a2-4de4-b119-83949690d7b6"), ColumnScheme.WEATHER, "its_weather_085d98ee-09a2-4de4-b119-83949690d7b6")
 		]
 
 		when:
@@ -97,7 +98,7 @@ class CsvFileConnectorTest extends Specification {
 
 	def "The csv file connector returns empty optional, if there is no meta information for queried time series"() {
 		when:
-		def actual = cfc.getIndividualTimeSeriesMetaInformation(UUID.fromString("2602e863-3eb6-480e-b752-a3e653af74ec"))
+		def actual = cfc.individualTimeSeriesMetaInformation(UUID.fromString("2602e863-3eb6-480e-b752-a3e653af74ec"))
 
 		then:
 		!actual.present
@@ -106,10 +107,10 @@ class CsvFileConnectorTest extends Specification {
 	def "The csv file connector returns correct individual time series meta information"() {
 		given:
 		def timeSeriesUuid = UUID.fromString("b88dee50-5484-4136-901d-050d8c1c97d1")
-		def expected = Optional.of(new CsvFileConnector.CsvIndividualTimeSeriesMetaInformation(timeSeriesUuid, ColumnScheme.ENERGY_PRICE, "its_c_b88dee50-5484-4136-901d-050d8c1c97d1"))
+		def expected = Optional.of(new CsvIndividualTimeSeriesMetaInformation(timeSeriesUuid, ColumnScheme.ENERGY_PRICE, "its_c_b88dee50-5484-4136-901d-050d8c1c97d1"))
 
 		when:
-		def actual = cfc.getIndividualTimeSeriesMetaInformation(timeSeriesUuid)
+		def actual = cfc.individualTimeSeriesMetaInformation(timeSeriesUuid)
 
 		then:
 		actual == expected
@@ -129,7 +130,7 @@ class CsvFileConnectorTest extends Specification {
 	def "The csv file connector is able to build correct meta information from valid input"() {
 		given:
 		def pathString = "its_pq_53990eea-1b5d-47e8-9134-6d8de36604bf"
-		def expected = new CsvFileConnector.CsvIndividualTimeSeriesMetaInformation(
+		def expected = new CsvIndividualTimeSeriesMetaInformation(
 				UUID.fromString("53990eea-1b5d-47e8-9134-6d8de36604bf"),
 				ColumnScheme.APPARENT_POWER,
 				""

--- a/src/test/groovy/edu/ie3/datamodel/io/csv/timeseries/ColumnSchemeTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/csv/timeseries/ColumnSchemeTest.groovy
@@ -5,7 +5,7 @@
  */
 package edu.ie3.datamodel.io.csv.timeseries
 
-import static edu.ie3.datamodel.io.csv.timeseries.ColumnScheme.*
+import static edu.ie3.datamodel.io.naming.timeseries.ColumnScheme.*
 
 import edu.ie3.datamodel.models.value.EnergyPriceValue
 import edu.ie3.datamodel.models.value.HeatAndPValue

--- a/src/test/groovy/edu/ie3/datamodel/io/naming/EntityPersistenceNamingStrategyTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/naming/EntityPersistenceNamingStrategyTest.groovy
@@ -137,7 +137,7 @@ class EntityPersistenceNamingStrategyTest extends Specification {
 		def fileName = "foo"
 
 		when:
-		fns.getIndividualTimesSeriesMetaInformation(fileName)
+		fns.getLoadProfileTimesSeriesMetaInformation(fileName)
 
 		then:
 		def ex = thrown(IllegalArgumentException)

--- a/src/test/groovy/edu/ie3/datamodel/io/naming/EntityPersistenceNamingStrategyTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/naming/EntityPersistenceNamingStrategyTest.groovy
@@ -82,11 +82,11 @@ class EntityPersistenceNamingStrategyTest extends Specification {
 
 	def "The pattern for an individual time series file name actually matches a valid file name and extracts the correct groups"() {
 		given:
-		def fns = new EntityPersistenceNamingStrategy()
+		def ens = new EntityPersistenceNamingStrategy()
 		def validFileName = "its_c_4881fda2-bcee-4f4f-a5bb-6a09bf785276"
 
 		when:
-		def matcher = fns.individualTimeSeriesPattern.matcher(validFileName)
+		def matcher = ens.individualTimeSeriesPattern.matcher(validFileName)
 
 		then: "the pattern matches"
 		matcher.matches()
@@ -101,11 +101,11 @@ class EntityPersistenceNamingStrategyTest extends Specification {
 
 	def "The pattern for a repetitive load profile time series file name actually matches a valid file name and extracts the correct groups"() {
 		given:
-		def fns = new EntityPersistenceNamingStrategy()
+		def ens = new EntityPersistenceNamingStrategy()
 		def validFileName = "lpts_g3_bee0a8b6-4788-4f18-bf72-be52035f7304"
 
 		when:
-		def matcher = fns.loadProfileTimeSeriesPattern.matcher(validFileName)
+		def matcher = ens.loadProfileTimeSeriesPattern.matcher(validFileName)
 
 		then: "the pattern matches"
 		matcher.matches()
@@ -120,11 +120,11 @@ class EntityPersistenceNamingStrategyTest extends Specification {
 
 	def "Trying to extract individual time series meta information throws an Exception, if it is provided a malformed string"() {
 		given:
-		def fns = new EntityPersistenceNamingStrategy()
+		def ens = new EntityPersistenceNamingStrategy()
 		def fileName = "foo"
 
 		when:
-		fns.getIndividualTimesSeriesMetaInformation(fileName)
+		ens.individualTimesSeriesMetaInformation(fileName)
 
 		then:
 		def ex = thrown(IllegalArgumentException)
@@ -133,11 +133,11 @@ class EntityPersistenceNamingStrategyTest extends Specification {
 
 	def "Trying to extract load profile time series meta information throws an Exception, if it is provided a malformed string"() {
 		given:
-		def fns = new EntityPersistenceNamingStrategy()
+		def ens = new EntityPersistenceNamingStrategy()
 		def fileName = "foo"
 
 		when:
-		fns.getLoadProfileTimesSeriesMetaInformation(fileName)
+		ens.loadProfileTimesSeriesMetaInformation(fileName)
 
 		then:
 		def ex = thrown(IllegalArgumentException)

--- a/src/test/groovy/edu/ie3/datamodel/io/naming/EntityPersistenceNamingStrategyTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/naming/EntityPersistenceNamingStrategyTest.groovy
@@ -124,7 +124,7 @@ class EntityPersistenceNamingStrategyTest extends Specification {
 		def fileName = "foo"
 
 		when:
-		fns.extractIndividualTimesSeriesMetaInformation(fileName)
+		fns.getIndividualTimesSeriesMetaInformation(fileName)
 
 		then:
 		def ex = thrown(IllegalArgumentException)
@@ -137,7 +137,7 @@ class EntityPersistenceNamingStrategyTest extends Specification {
 		def fileName = "foo"
 
 		when:
-		fns.extractLoadProfileTimesSeriesMetaInformation(fileName)
+		fns.getIndividualTimesSeriesMetaInformation(fileName)
 
 		then:
 		def ex = thrown(IllegalArgumentException)

--- a/src/test/groovy/edu/ie3/datamodel/io/naming/FileNamingStrategyTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/naming/FileNamingStrategyTest.groovy
@@ -5,9 +5,9 @@
  */
 package edu.ie3.datamodel.io.naming
 
-import edu.ie3.datamodel.io.csv.timeseries.ColumnScheme
-import edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation
-import edu.ie3.datamodel.io.csv.timeseries.LoadProfileTimeSeriesMetaInformation
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme
+import edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation
+import edu.ie3.datamodel.io.naming.timeseries.LoadProfileTimeSeriesMetaInformation
 import edu.ie3.datamodel.io.source.TimeSeriesMappingSource
 import edu.ie3.datamodel.models.BdewLoadProfile
 import edu.ie3.datamodel.models.UniqueEntity
@@ -820,7 +820,7 @@ class FileNamingStrategyTest extends Specification {
 		def path = Paths.get("/bla/foo")
 
 		when:
-		fns.extractTimeSeriesMetaInformation(path)
+		fns.timeSeriesMetaInformation(path)
 
 		then:
 		def ex = thrown(IllegalArgumentException)
@@ -833,7 +833,7 @@ class FileNamingStrategyTest extends Specification {
 		def path = Paths.get(pathString)
 
 		when:
-		def metaInformation = fns.extractTimeSeriesMetaInformation(path)
+		def metaInformation = fns.timeSeriesMetaInformation(path)
 
 		then:
 		IndividualTimeSeriesMetaInformation.isAssignableFrom(metaInformation.getClass())
@@ -859,7 +859,7 @@ class FileNamingStrategyTest extends Specification {
 		def path = Paths.get(pathString)
 
 		when:
-		def metaInformation = fns.extractTimeSeriesMetaInformation(path)
+		def metaInformation = fns.timeSeriesMetaInformation(path)
 
 		then:
 		IndividualTimeSeriesMetaInformation.isAssignableFrom(metaInformation.getClass())
@@ -885,7 +885,7 @@ class FileNamingStrategyTest extends Specification {
 		def path = Paths.get("/bla/foo/its_whoops_4881fda2-bcee-4f4f-a5bb-6a09bf785276.csv")
 
 		when:
-		fns.extractTimeSeriesMetaInformation(path)
+		fns.timeSeriesMetaInformation(path)
 
 		then:
 		def ex = thrown(IllegalArgumentException)
@@ -898,7 +898,7 @@ class FileNamingStrategyTest extends Specification {
 		def path = Paths.get("/bla/foo/lpts_g3_bee0a8b6-4788-4f18-bf72-be52035f7304.csv")
 
 		when:
-		def metaInformation = fns.extractTimeSeriesMetaInformation(path)
+		def metaInformation = fns.timeSeriesMetaInformation(path)
 
 		then:
 		LoadProfileTimeSeriesMetaInformation.isAssignableFrom(metaInformation.getClass())
@@ -914,7 +914,7 @@ class FileNamingStrategyTest extends Specification {
 		def path = Paths.get("/bla/foo/prefix_lpts_g3_bee0a8b6-4788-4f18-bf72-be52035f7304_suffix.csv")
 
 		when:
-		def metaInformation = fns.extractTimeSeriesMetaInformation(path)
+		def metaInformation = fns.timeSeriesMetaInformation(path)
 
 		then:
 		LoadProfileTimeSeriesMetaInformation.isAssignableFrom(metaInformation.getClass())

--- a/src/test/groovy/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesMappingSourceIT.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesMappingSourceIT.groovy
@@ -5,9 +5,9 @@
  */
 package edu.ie3.datamodel.io.source.csv
 
+import edu.ie3.datamodel.io.csv.CsvIndividualTimeSeriesMetaInformation
 import edu.ie3.datamodel.io.naming.FileNamingStrategy
-import edu.ie3.datamodel.io.connectors.CsvFileConnector
-import edu.ie3.datamodel.io.csv.timeseries.ColumnScheme
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme
 import edu.ie3.datamodel.io.source.TimeSeriesMappingSource
 import spock.lang.Shared
 import spock.lang.Specification
@@ -68,7 +68,7 @@ class CsvTimeSeriesMappingSourceIT extends Specification implements CsvTestDataM
 		def timeSeriesUuid = UUID.fromString("f5eb3be5-98db-40de-85b0-243507636cd5")
 
 		when:
-		def actual = source.getTimeSeriesMetaInformation(timeSeriesUuid)
+		def actual = source.timeSeriesMetaInformation(timeSeriesUuid)
 
 		then:
 		!actual.present
@@ -77,13 +77,13 @@ class CsvTimeSeriesMappingSourceIT extends Specification implements CsvTestDataM
 	def "A csv time series mapping source returns correct meta information for an existing time series"() {
 		given:
 		def timeSeriesUuid = UUID.fromString("3fbfaa97-cff4-46d4-95ba-a95665e87c26")
-		def expected = new CsvFileConnector.CsvIndividualTimeSeriesMetaInformation(
+		def expected = new CsvIndividualTimeSeriesMetaInformation(
 				timeSeriesUuid,
 				ColumnScheme.APPARENT_POWER,
 				"its_pq_3fbfaa97-cff4-46d4-95ba-a95665e87c26")
 
 		when:
-		def actual = source.getTimeSeriesMetaInformation(timeSeriesUuid)
+		def actual = source.timeSeriesMetaInformation(timeSeriesUuid)
 
 		then:
 		actual.present

--- a/src/test/groovy/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesSourceTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesSourceTest.groovy
@@ -5,13 +5,13 @@
  */
 package edu.ie3.datamodel.io.source.csv
 
+import edu.ie3.datamodel.io.csv.CsvIndividualTimeSeriesMetaInformation
 import edu.ie3.datamodel.io.naming.FileNamingStrategy
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme
 
 import static edu.ie3.datamodel.models.StandardUnits.ENERGY_PRICE
 
 import edu.ie3.datamodel.exceptions.SourceException
-import edu.ie3.datamodel.io.connectors.CsvFileConnector
-import edu.ie3.datamodel.io.csv.timeseries.ColumnScheme
 import edu.ie3.datamodel.io.factory.timeseries.TimeBasedSimpleValueFactory
 import edu.ie3.datamodel.models.timeseries.individual.TimeBasedValue
 import edu.ie3.datamodel.models.value.*
@@ -50,7 +50,7 @@ class CsvTimeSeriesSourceTest extends Specification implements CsvTestDataMeta {
 
 	def "The factory method in csv time series source refuses to build time series with unsupported column type"() {
 		given:
-		def metaInformation = new CsvFileConnector.CsvIndividualTimeSeriesMetaInformation(UUID.fromString("8bc9120d-fb9b-4484-b4e3-0cdadf0feea9"), ColumnScheme.WEATHER, "its_weather_8bc9120d-fb9b-4484-b4e3-0cdadf0feea9")
+		def metaInformation = new CsvIndividualTimeSeriesMetaInformation(UUID.fromString("8bc9120d-fb9b-4484-b4e3-0cdadf0feea9"), ColumnScheme.WEATHER, "its_weather_8bc9120d-fb9b-4484-b4e3-0cdadf0feea9")
 
 		when:
 		CsvTimeSeriesSource.getSource(";", timeSeriesFolderPath, fileNamingStrategy, metaInformation)
@@ -62,7 +62,7 @@ class CsvTimeSeriesSourceTest extends Specification implements CsvTestDataMeta {
 
 	def "The factory method in csv time series source builds a time series source for all supported column types"() {
 		given:
-		def metaInformation = new CsvFileConnector.CsvIndividualTimeSeriesMetaInformation(uuid, columnScheme, path)
+		def metaInformation = new CsvIndividualTimeSeriesMetaInformation(uuid, columnScheme, path)
 
 		when:
 		def actual = CsvTimeSeriesSource.getSource(";", timeSeriesFolderPath, fileNamingStrategy, metaInformation)

--- a/src/test/groovy/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesMappingSourceIT.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesMappingSourceIT.groovy
@@ -6,9 +6,9 @@
 package edu.ie3.datamodel.io.source.sql
 
 import edu.ie3.datamodel.io.connectors.SqlConnector
-import edu.ie3.datamodel.io.csv.timeseries.ColumnScheme
-import edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation
 import edu.ie3.datamodel.io.naming.EntityPersistenceNamingStrategy
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme
+import edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation
 import org.testcontainers.containers.Container
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.spock.Testcontainers
@@ -84,7 +84,7 @@ class SqlTimeSeriesMappingSourceIT extends Specification {
 		def timeSeriesUuid = UUID.fromString("f5eb3be5-98db-40de-85b0-243507636cd5")
 
 		when:
-		def actual = source.getTimeSeriesMetaInformation(timeSeriesUuid)
+		def actual = source.timeSeriesMetaInformation(timeSeriesUuid)
 
 		then:
 		!actual.present
@@ -98,7 +98,7 @@ class SqlTimeSeriesMappingSourceIT extends Specification {
 				ColumnScheme.ACTIVE_POWER)
 
 		when:
-		def actual = source.getTimeSeriesMetaInformation(timeSeriesUuid)
+		def actual = source.timeSeriesMetaInformation(timeSeriesUuid)
 
 		then:
 		actual.present

--- a/src/test/groovy/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesSourceIT.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesSourceIT.groovy
@@ -7,10 +7,10 @@ package edu.ie3.datamodel.io.source.sql
 
 import static edu.ie3.test.common.TimeSeriesSourceTestData.*
 
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme
+import edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation
 import edu.ie3.datamodel.exceptions.SourceException
 import edu.ie3.datamodel.io.connectors.SqlConnector
-import edu.ie3.datamodel.io.csv.timeseries.ColumnScheme
-import edu.ie3.datamodel.io.csv.timeseries.IndividualTimeSeriesMetaInformation
 import edu.ie3.datamodel.models.value.*
 import edu.ie3.util.interval.ClosedInterval
 import org.testcontainers.containers.Container

--- a/src/test/groovy/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesSourceIT.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/source/sql/SqlTimeSeriesSourceIT.groovy
@@ -7,10 +7,10 @@ package edu.ie3.datamodel.io.source.sql
 
 import static edu.ie3.test.common.TimeSeriesSourceTestData.*
 
-import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme
-import edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation
 import edu.ie3.datamodel.exceptions.SourceException
 import edu.ie3.datamodel.io.connectors.SqlConnector
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme
+import edu.ie3.datamodel.io.sql.SqlIndividualTimeSeriesMetaInformation
 import edu.ie3.datamodel.models.value.*
 import edu.ie3.util.interval.ClosedInterval
 import org.testcontainers.containers.Container
@@ -64,21 +64,22 @@ class SqlTimeSeriesSourceIT extends Specification {
 		}
 
 		connector = new SqlConnector(postgreSQLContainer.jdbcUrl, postgreSQLContainer.username, postgreSQLContainer.password)
-		def metaInformation = new IndividualTimeSeriesMetaInformation(
+		def metaInformation = new SqlIndividualTimeSeriesMetaInformation(
 				timeSeriesUuid,
-				ColumnScheme.ACTIVE_POWER
+				ColumnScheme.ACTIVE_POWER,
+				pTableName
 				)
 
-		pSource = SqlTimeSeriesSource.getSource(connector, schemaName, pTableName, metaInformation, "yyyy-MM-dd HH:mm:ss")
+		pSource = SqlTimeSeriesSource.getSource(connector, schemaName, metaInformation, "yyyy-MM-dd HH:mm:ss")
 	}
 
 	def "The factory method in SqlTimeSeriesSource builds a time series source for all supported column types"() {
 		given:
-		def metaInformation = new IndividualTimeSeriesMetaInformation(uuid, columnScheme)
+		def metaInformation = new SqlIndividualTimeSeriesMetaInformation(uuid, columnScheme, tableName)
 		def timePattern = "yyyy-MM-dd HH:mm:ss"
 
 		when:
-		def actual = SqlTimeSeriesSource.getSource(connector, schemaName, tableName, metaInformation, timePattern)
+		def actual = SqlTimeSeriesSource.getSource(connector, schemaName, metaInformation, timePattern)
 
 		then:
 		actual.timeSeries.entries.size() == amountOfEntries
@@ -96,14 +97,15 @@ class SqlTimeSeriesSourceIT extends Specification {
 
 	def "The factory method in SqlTimeSeriesSource refuses to build time series with unsupported column type"() {
 		given:
-		def metaInformation = new IndividualTimeSeriesMetaInformation(
+		def metaInformation = new SqlIndividualTimeSeriesMetaInformation(
 				UUID.fromString("8bc9120d-fb9b-4484-b4e3-0cdadf0feea9"),
-				ColumnScheme.WEATHER
+				ColumnScheme.WEATHER,
+				"weather"
 				)
 		def timePattern = "yyyy-MM-dd HH:mm:ss"
 
 		when:
-		SqlTimeSeriesSource.getSource(connector, schemaName, "weather", metaInformation, timePattern)
+		SqlTimeSeriesSource.getSource(connector, schemaName, metaInformation, timePattern)
 
 		then:
 		def e = thrown(SourceException)


### PR DESCRIPTION
Resolves #513 

Additions:
- `SqlIndividualTimeSeriesMetaInformation` analogous to `CsvIndividualTimeSeriesMetaInformation`

Adapted:
- `SqlTimeSeriesSource`
- `SqlTimeSeriesMappingSource`
- Tests

Refactorings (old classes deprecated):
- Moved from `edu.ie3.datamodel.io.csv` to `edu.ie3.datamodel.io.naming`: `FileNameMetaInformation` (renamed to `TimeSeriesMetaInformation`)
- Moved from `edu.ie3.datamodel.io.csv.timeseries` to `edu.ie3.datamodel.io.naming.timeseries`: `IndividualTimeSeriesMetaInformation`, `LoadProfileTimeSeriesMetaInformation`, `ColumnScheme`
- Moved from `edu.ie3.datamodel.io.connectors.CsvFileConnector` (static inner class) to `edu.ie3.datamodel.io.csv`: `CsvIndividualTimeSeriesMetaInformation`
