### PR TITLE
Exclude spock milesone versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,4 @@ updates:
         - "2.2-groovy-4.0-SNAPSHOT"
         - "2.2-groovy-3.0-SNAPSHOT"
         - "2.2-groovy-2.5-SNAPSHOT"
+        - "2.2-M1-groovy-4.0"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,9 +17,14 @@ updates:
   ignore:
   - dependency-name: org.spockframework:spock-core
     versions:
-        - "2.1-groovy-3.0-SNAPSHOT"
-        - "2.1-groovy-2.5-SNAPSHOT"
-        - "2.2-groovy-4.0-SNAPSHOT"
-        - "2.2-groovy-3.0-SNAPSHOT"
-        - "2.2-groovy-2.5-SNAPSHOT"
-        - "2.2-M1-groovy-4.0"
+        - 2.1-groovy-2.5-SNAPSHOT
+        - 2.1-groovy-3.0-SNAPSHOT
+        - 2.2-groovy-2.5-SNAPSHOT
+        - 2.2-groovy-3.0-SNAPSHOT
+        - 2.2-groovy-4.0-SNAPSHOT
+        - 2.2-M1-groovy-2.5
+        - 2.2-M1-groovy-3.0
+        - 2.2-M1-groovy-4.0
+        - 2.2-M2-groovy-2.5
+        - 2.2-M2-groovy-3.0
+        - 2.2-M2-groovy-4.0


### PR DESCRIPTION
`M` versions are milestone versions (somewhere between snapshot and release candidate), while we should use release versions. Thus, exclude milestone versions.

Also included are probable future versions (`2.2-M2`) which might come up at some point.