### PR TITLE
Sp/#607 profile parse method

### DIFF
--- a/src/main/java/edu/ie3/datamodel/models/profile/BdewStandardLoadProfile.java
+++ b/src/main/java/edu/ie3/datamodel/models/profile/BdewStandardLoadProfile.java
@@ -5,6 +5,8 @@
 */
 package edu.ie3.datamodel.models.profile;
 
+import edu.ie3.datamodel.exceptions.ParsingException;
+
 /**
  * German standard electricity load profiles, defined by the bdew (Bundesverband der Energie- und
  * Wasserwirtschaft; engl.Federal Association of the Energy and Water Industry). For more details
@@ -36,8 +38,8 @@ public enum BdewStandardLoadProfile implements StandardLoadProfile {
    * @return The corresponding bdew load profile or throw {@link IllegalArgumentException}, if no
    *     matching load profile can be found
    */
-  public static BdewStandardLoadProfile get(String key) {
-    return (BdewStandardLoadProfile) LoadProfile.getProfile(BdewStandardLoadProfile.values(), key);
+  public static BdewStandardLoadProfile get(String key) throws ParsingException {
+    return LoadProfile.getProfile(BdewStandardLoadProfile.values(), key);
   }
 
   @Override

--- a/src/main/java/edu/ie3/datamodel/models/profile/LoadProfile.java
+++ b/src/main/java/edu/ie3/datamodel/models/profile/LoadProfile.java
@@ -36,6 +36,12 @@ public interface LoadProfile extends Serializable {
                 new ParsingException("Cannot parse \"" + key + "\" to a valid known load profile"));
   }
 
+  /** Looks for load profile with given key and returns it.
+   *
+   * @param profiles we search within
+   * @param key to look for
+   * @return the matching load profile
+   */
   static LoadProfile getProfile(LoadProfile[] profiles, String key) {
     return Arrays.stream(profiles)
         .filter(loadProfile -> loadProfile.getKey().equalsIgnoreCase(getUniformKey(key)))

--- a/src/main/java/edu/ie3/datamodel/models/profile/LoadProfile.java
+++ b/src/main/java/edu/ie3/datamodel/models/profile/LoadProfile.java
@@ -36,7 +36,8 @@ public interface LoadProfile extends Serializable {
                 new ParsingException("Cannot parse \"" + key + "\" to a valid known load profile"));
   }
 
-  /** Looks for load profile with given key and returns it.
+  /**
+   * Looks for load profile with given key and returns it.
    *
    * @param profiles we search within
    * @param key to look for

--- a/src/main/java/edu/ie3/datamodel/models/profile/LoadProfile.java
+++ b/src/main/java/edu/ie3/datamodel/models/profile/LoadProfile.java
@@ -9,7 +9,6 @@ import edu.ie3.datamodel.exceptions.ParsingException;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public interface LoadProfile extends Serializable {
   /** @return The identifying String */
@@ -25,15 +24,16 @@ public interface LoadProfile extends Serializable {
   static LoadProfile parse(String key) throws ParsingException {
     if (key == null || key.isEmpty()) return LoadProfile.DefaultLoadProfiles.NO_LOAD_PROFILE;
 
-    String filterKey = getUniformKey(key);
-    return Stream.concat(
-            Arrays.stream(BdewStandardLoadProfile.values()),
-            Arrays.stream(NbwTemperatureDependantLoadProfile.values()))
-        .filter(profile -> profile.getKey().equals(filterKey))
-        .findFirst()
-        .orElseThrow(
-            () ->
-                new ParsingException("Cannot parse \"" + key + "\" to a valid known load profile"));
+    return LoadProfile.getProfile(getAllProfiles(), key);
+  }
+
+  static LoadProfile[] getAllProfiles() {
+    final LoadProfile[][] all =
+        new LoadProfile[][] {
+          BdewStandardLoadProfile.values(), NbwTemperatureDependantLoadProfile.values()
+        };
+
+    return Arrays.stream(all).flatMap(Arrays::stream).toArray(LoadProfile[]::new);
   }
 
   /**
@@ -43,16 +43,16 @@ public interface LoadProfile extends Serializable {
    * @param key to look for
    * @return the matching load profile
    */
-  static LoadProfile getProfile(LoadProfile[] profiles, String key) {
+  static <T extends LoadProfile> T getProfile(T[] profiles, String key) throws ParsingException {
     return Arrays.stream(profiles)
         .filter(loadProfile -> loadProfile.getKey().equalsIgnoreCase(getUniformKey(key)))
         .findFirst()
         .orElseThrow(
             () ->
-                new IllegalArgumentException(
+                new ParsingException(
                     "No predefined load profile with key '"
                         + key
-                        + "' found. Please provide one of the following keys:"
+                        + "' found. Please provide one of the following keys: "
                         + Arrays.stream(profiles)
                             .map(LoadProfile::getKey)
                             .collect(Collectors.joining(", "))));

--- a/src/main/java/edu/ie3/datamodel/models/profile/LoadProfile.java
+++ b/src/main/java/edu/ie3/datamodel/models/profile/LoadProfile.java
@@ -9,23 +9,11 @@ import edu.ie3.datamodel.exceptions.ParsingException;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.ArrayUtils;
+import java.util.stream.Stream;
 
 public interface LoadProfile extends Serializable {
   /** @return The identifying String */
   String getKey();
-
-  static LoadProfile parse(LoadProfile[] profiles, String key) throws ParsingException {
-    if (key == null || key.isEmpty()) return LoadProfile.DefaultLoadProfiles.NO_LOAD_PROFILE;
-
-    String filterKey = getUniformKey(key);
-    return Arrays.stream(profiles)
-        .filter(profile -> profile.getKey().equals(filterKey))
-        .findFirst()
-        .orElseThrow(
-            () ->
-                new ParsingException("Cannot parse \"" + key + "\" to a valid known load profile"));
-  }
 
   /**
    * Parses the given key to {@link StandardLoadProfile}.
@@ -35,10 +23,17 @@ public interface LoadProfile extends Serializable {
    * @throws ParsingException If key cannot be parsed
    */
   static LoadProfile parse(String key) throws ParsingException {
-    return parse(
-        ArrayUtils.addAll(
-            BdewStandardLoadProfile.values(), NbwTemperatureDependantLoadProfile.values()),
-        key);
+    if (key == null || key.isEmpty()) return LoadProfile.DefaultLoadProfiles.NO_LOAD_PROFILE;
+
+    String filterKey = getUniformKey(key);
+    return Stream.concat(
+            Arrays.stream(BdewStandardLoadProfile.values()),
+            Arrays.stream(NbwTemperatureDependantLoadProfile.values()))
+        .filter(profile -> profile.getKey().equals(filterKey))
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new ParsingException("Cannot parse \"" + key + "\" to a valid known load profile"));
   }
 
   static LoadProfile getProfile(LoadProfile[] profiles, String key) {

--- a/src/main/java/edu/ie3/datamodel/models/profile/NbwTemperatureDependantLoadProfile.java
+++ b/src/main/java/edu/ie3/datamodel/models/profile/NbwTemperatureDependantLoadProfile.java
@@ -5,6 +5,8 @@
 */
 package edu.ie3.datamodel.models.profile;
 
+import edu.ie3.datamodel.exceptions.ParsingException;
+
 /** Temperature dependant determined by NBW (accessed 05/2022) */
 public enum NbwTemperatureDependantLoadProfile implements TemperatureDependantLoadProfile {
   // heat pumps
@@ -26,9 +28,8 @@ public enum NbwTemperatureDependantLoadProfile implements TemperatureDependantLo
    * @return The corresponding nbw load profile or throw {@link IllegalArgumentException}, if no
    *     matching load profile can be found
    */
-  public static NbwTemperatureDependantLoadProfile get(String key) {
-    return (NbwTemperatureDependantLoadProfile)
-        LoadProfile.getProfile(NbwTemperatureDependantLoadProfile.values(), key);
+  public static NbwTemperatureDependantLoadProfile get(String key) throws ParsingException {
+    return LoadProfile.getProfile(NbwTemperatureDependantLoadProfile.values(), key);
   }
 
   @Override

--- a/src/main/java/edu/ie3/datamodel/models/profile/StandardLoadProfile.java
+++ b/src/main/java/edu/ie3/datamodel/models/profile/StandardLoadProfile.java
@@ -5,6 +5,7 @@
 */
 package edu.ie3.datamodel.models.profile;
 
+import edu.ie3.datamodel.exceptions.ParsingException;
 import edu.ie3.datamodel.models.timeseries.individual.IndividualTimeSeries;
 import edu.ie3.datamodel.models.timeseries.repetitive.RepetitiveTimeSeries;
 
@@ -16,4 +17,9 @@ import edu.ie3.datamodel.models.timeseries.repetitive.RepetitiveTimeSeries;
  * <p>If you intend to provide distinct values, create either an {@link IndividualTimeSeries} or
  * {@link RepetitiveTimeSeries} and assign it to the model via mapping to the model.
  */
-public interface StandardLoadProfile extends LoadProfile {}
+public interface StandardLoadProfile extends LoadProfile {
+
+  static StandardLoadProfile parse(String key) throws ParsingException {
+    return (StandardLoadProfile) LoadProfile.parse(BdewStandardLoadProfile.values(), key);
+  }
+}

--- a/src/main/java/edu/ie3/datamodel/models/profile/StandardLoadProfile.java
+++ b/src/main/java/edu/ie3/datamodel/models/profile/StandardLoadProfile.java
@@ -18,6 +18,11 @@ import edu.ie3.datamodel.models.timeseries.repetitive.RepetitiveTimeSeries;
  */
 public interface StandardLoadProfile extends LoadProfile {
 
+  /** Returns standard load profile corresponding to the given key.
+   *
+   * @param key to look for
+   * @return the matching standard load profile
+   */
   static StandardLoadProfile parse(String key) {
     return (StandardLoadProfile) LoadProfile.getProfile(BdewStandardLoadProfile.values(), key);
   }

--- a/src/main/java/edu/ie3/datamodel/models/profile/StandardLoadProfile.java
+++ b/src/main/java/edu/ie3/datamodel/models/profile/StandardLoadProfile.java
@@ -16,4 +16,9 @@ import edu.ie3.datamodel.models.timeseries.repetitive.RepetitiveTimeSeries;
  * <p>If you intend to provide distinct values, create either an {@link IndividualTimeSeries} or
  * {@link RepetitiveTimeSeries} and assign it to the model via mapping to the model.
  */
-public interface StandardLoadProfile extends LoadProfile {}
+public interface StandardLoadProfile extends LoadProfile {
+
+  static StandardLoadProfile parse(String key) {
+    return (StandardLoadProfile) LoadProfile.getProfile(BdewStandardLoadProfile.values(), key);
+  }
+}

--- a/src/main/java/edu/ie3/datamodel/models/profile/StandardLoadProfile.java
+++ b/src/main/java/edu/ie3/datamodel/models/profile/StandardLoadProfile.java
@@ -18,7 +18,8 @@ import edu.ie3.datamodel.models.timeseries.repetitive.RepetitiveTimeSeries;
  */
 public interface StandardLoadProfile extends LoadProfile {
 
-  /** Returns standard load profile corresponding to the given key.
+  /**
+   * Returns standard load profile corresponding to the given key.
    *
    * @param key to look for
    * @return the matching standard load profile

--- a/src/main/java/edu/ie3/datamodel/models/profile/StandardLoadProfile.java
+++ b/src/main/java/edu/ie3/datamodel/models/profile/StandardLoadProfile.java
@@ -5,7 +5,6 @@
 */
 package edu.ie3.datamodel.models.profile;
 
-import edu.ie3.datamodel.exceptions.ParsingException;
 import edu.ie3.datamodel.models.timeseries.individual.IndividualTimeSeries;
 import edu.ie3.datamodel.models.timeseries.repetitive.RepetitiveTimeSeries;
 
@@ -17,9 +16,4 @@ import edu.ie3.datamodel.models.timeseries.repetitive.RepetitiveTimeSeries;
  * <p>If you intend to provide distinct values, create either an {@link IndividualTimeSeries} or
  * {@link RepetitiveTimeSeries} and assign it to the model via mapping to the model.
  */
-public interface StandardLoadProfile extends LoadProfile {
-
-  static StandardLoadProfile parse(String key) throws ParsingException {
-    return (StandardLoadProfile) LoadProfile.parse(BdewStandardLoadProfile.values(), key);
-  }
-}
+public interface StandardLoadProfile extends LoadProfile {}

--- a/src/main/java/edu/ie3/datamodel/models/profile/StandardLoadProfile.java
+++ b/src/main/java/edu/ie3/datamodel/models/profile/StandardLoadProfile.java
@@ -5,6 +5,7 @@
 */
 package edu.ie3.datamodel.models.profile;
 
+import edu.ie3.datamodel.exceptions.ParsingException;
 import edu.ie3.datamodel.models.timeseries.individual.IndividualTimeSeries;
 import edu.ie3.datamodel.models.timeseries.repetitive.RepetitiveTimeSeries;
 
@@ -24,7 +25,7 @@ public interface StandardLoadProfile extends LoadProfile {
    * @param key to look for
    * @return the matching standard load profile
    */
-  static StandardLoadProfile parse(String key) {
-    return (StandardLoadProfile) LoadProfile.getProfile(BdewStandardLoadProfile.values(), key);
+  static StandardLoadProfile parse(String key) throws ParsingException {
+    return LoadProfile.getProfile(BdewStandardLoadProfile.values(), key);
   }
 }

--- a/src/main/java/edu/ie3/datamodel/models/profile/TemperatureDependantLoadProfile.java
+++ b/src/main/java/edu/ie3/datamodel/models/profile/TemperatureDependantLoadProfile.java
@@ -5,9 +5,17 @@
 */
 package edu.ie3.datamodel.models.profile;
 
+import edu.ie3.datamodel.exceptions.ParsingException;
+
 /**
  * Temperature dependant load profiles for night storage heating and heat pumps . The profiles rely
  * on the VDN description for interruptable loads. For more details see <a
  * href="https://www.bdew.de/media/documents/LPuVe-Praxisleitfaden.pdf">here</a>.
  */
-public interface TemperatureDependantLoadProfile extends LoadProfile {}
+public interface TemperatureDependantLoadProfile extends LoadProfile {
+
+  static NbwTemperatureDependantLoadProfile parse(String key) throws ParsingException {
+    return (NbwTemperatureDependantLoadProfile)
+        LoadProfile.parse(NbwTemperatureDependantLoadProfile.values(), key);
+  }
+}

--- a/src/main/java/edu/ie3/datamodel/models/profile/TemperatureDependantLoadProfile.java
+++ b/src/main/java/edu/ie3/datamodel/models/profile/TemperatureDependantLoadProfile.java
@@ -10,4 +10,10 @@ package edu.ie3.datamodel.models.profile;
  * on the VDN description for interruptable loads. For more details see <a
  * href="https://www.bdew.de/media/documents/LPuVe-Praxisleitfaden.pdf">here</a>.
  */
-public interface TemperatureDependantLoadProfile extends LoadProfile {}
+public interface TemperatureDependantLoadProfile extends LoadProfile {
+
+  static TemperatureDependantLoadProfile parse(String key) {
+    return (NbwTemperatureDependantLoadProfile)
+        LoadProfile.getProfile(NbwTemperatureDependantLoadProfile.values(), key);
+  }
+}

--- a/src/main/java/edu/ie3/datamodel/models/profile/TemperatureDependantLoadProfile.java
+++ b/src/main/java/edu/ie3/datamodel/models/profile/TemperatureDependantLoadProfile.java
@@ -12,6 +12,11 @@ package edu.ie3.datamodel.models.profile;
  */
 public interface TemperatureDependantLoadProfile extends LoadProfile {
 
+  /** Returns temperature dependant load profile corresponding to the given key.
+   *
+   * @param key to look for
+   * @return the matching temperature dependant load profile
+   */
   static TemperatureDependantLoadProfile parse(String key) {
     return (NbwTemperatureDependantLoadProfile)
         LoadProfile.getProfile(NbwTemperatureDependantLoadProfile.values(), key);

--- a/src/main/java/edu/ie3/datamodel/models/profile/TemperatureDependantLoadProfile.java
+++ b/src/main/java/edu/ie3/datamodel/models/profile/TemperatureDependantLoadProfile.java
@@ -5,6 +5,8 @@
 */
 package edu.ie3.datamodel.models.profile;
 
+import edu.ie3.datamodel.exceptions.ParsingException;
+
 /**
  * Temperature dependant load profiles for night storage heating and heat pumps . The profiles rely
  * on the VDN description for interruptable loads. For more details see <a
@@ -18,8 +20,7 @@ public interface TemperatureDependantLoadProfile extends LoadProfile {
    * @param key to look for
    * @return the matching temperature dependant load profile
    */
-  static TemperatureDependantLoadProfile parse(String key) {
-    return (NbwTemperatureDependantLoadProfile)
-        LoadProfile.getProfile(NbwTemperatureDependantLoadProfile.values(), key);
+  static TemperatureDependantLoadProfile parse(String key) throws ParsingException {
+    return LoadProfile.getProfile(NbwTemperatureDependantLoadProfile.values(), key);
   }
 }

--- a/src/main/java/edu/ie3/datamodel/models/profile/TemperatureDependantLoadProfile.java
+++ b/src/main/java/edu/ie3/datamodel/models/profile/TemperatureDependantLoadProfile.java
@@ -5,17 +5,9 @@
 */
 package edu.ie3.datamodel.models.profile;
 
-import edu.ie3.datamodel.exceptions.ParsingException;
-
 /**
  * Temperature dependant load profiles for night storage heating and heat pumps . The profiles rely
  * on the VDN description for interruptable loads. For more details see <a
  * href="https://www.bdew.de/media/documents/LPuVe-Praxisleitfaden.pdf">here</a>.
  */
-public interface TemperatureDependantLoadProfile extends LoadProfile {
-
-  static NbwTemperatureDependantLoadProfile parse(String key) throws ParsingException {
-    return (NbwTemperatureDependantLoadProfile)
-        LoadProfile.parse(NbwTemperatureDependantLoadProfile.values(), key);
-  }
-}
+public interface TemperatureDependantLoadProfile extends LoadProfile {}

--- a/src/main/java/edu/ie3/datamodel/models/profile/TemperatureDependantLoadProfile.java
+++ b/src/main/java/edu/ie3/datamodel/models/profile/TemperatureDependantLoadProfile.java
@@ -12,7 +12,8 @@ package edu.ie3.datamodel.models.profile;
  */
 public interface TemperatureDependantLoadProfile extends LoadProfile {
 
-  /** Returns temperature dependant load profile corresponding to the given key.
+  /**
+   * Returns temperature dependant load profile corresponding to the given key.
    *
    * @param key to look for
    * @return the matching temperature dependant load profile

--- a/src/test/groovy/edu/ie3/datamodel/models/LoadProfileTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/LoadProfileTest.groovy
@@ -9,6 +9,8 @@ import edu.ie3.datamodel.exceptions.ParsingException
 import edu.ie3.datamodel.models.profile.BdewStandardLoadProfile
 import edu.ie3.datamodel.models.profile.LoadProfile
 import edu.ie3.datamodel.models.profile.NbwTemperatureDependantLoadProfile
+import edu.ie3.datamodel.models.profile.StandardLoadProfile
+import edu.ie3.datamodel.models.profile.TemperatureDependantLoadProfile
 import spock.lang.Specification
 
 class LoadProfileTest extends Specification {
@@ -93,6 +95,40 @@ class LoadProfileTest extends Specification {
 		null    || LoadProfile.DefaultLoadProfiles.NO_LOAD_PROFILE
 	}
 
+	def "Standard load profiles can be parsed correctly"() {
+		when:
+		StandardLoadProfile actual = StandardLoadProfile.parse(key)
+
+		then:
+		actual == expected
+
+		where:
+		key     || expected
+		"h0"    || BdewStandardLoadProfile.H0
+		"h-0"   || BdewStandardLoadProfile.H0
+		"h_0"   || BdewStandardLoadProfile.H0
+		"H0"    || BdewStandardLoadProfile.H0
+		"H-0"   || BdewStandardLoadProfile.H0
+		"H_0"   || BdewStandardLoadProfile.H0
+	}
+
+	def "Tempearture dependent load profiles can be parsed correctly"() {
+		when:
+		TemperatureDependantLoadProfile actual = TemperatureDependantLoadProfile.parse(key)
+
+		then:
+		actual == expected
+
+		where:
+		key       || expected
+		"ep1"     || NbwTemperatureDependantLoadProfile.EP1
+		"ep_1"    || NbwTemperatureDependantLoadProfile.EP1
+		"ep_1"    || NbwTemperatureDependantLoadProfile.EP1
+		"ez2"     || NbwTemperatureDependantLoadProfile.EZ2
+		"ez-2"    || NbwTemperatureDependantLoadProfile.EZ2
+		"ez_2"    || NbwTemperatureDependantLoadProfile.EZ2
+	}
+
 	def "BDEW load profiles can be gotten by their key"() {
 		when:
 		BdewStandardLoadProfile actual = BdewStandardLoadProfile.get(key)
@@ -111,6 +147,23 @@ class LoadProfileTest extends Specification {
 		"g1"     || BdewStandardLoadProfile.G1
 		"g-1"    || BdewStandardLoadProfile.G1
 		"g_1"    || BdewStandardLoadProfile.G1
+	}
+
+	def "Nbw temperature dependant load profiles can be parsed correctly"() {
+		when:
+		NbwTemperatureDependantLoadProfile actual = NbwTemperatureDependantLoadProfile.get(key)
+
+		then:
+		actual == expected
+
+		where:
+		key       || expected
+		"ep1"     || NbwTemperatureDependantLoadProfile.EP1
+		"ep_1"    || NbwTemperatureDependantLoadProfile.EP1
+		"ep_1"    || NbwTemperatureDependantLoadProfile.EP1
+		"ez2"     || NbwTemperatureDependantLoadProfile.EZ2
+		"ez-2"    || NbwTemperatureDependantLoadProfile.EZ2
+		"ez_2"    || NbwTemperatureDependantLoadProfile.EZ2
 	}
 
 	def "Nbw temperature dependant load profiles can be gotten by their key"() {

--- a/src/test/groovy/edu/ie3/datamodel/models/profile/LoadProfileTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/profile/LoadProfileTest.groovy
@@ -3,14 +3,9 @@
  * Institute of Energy Systems, Energy Efficiency and Energy Economics,
  * Research group Distribution grid planning and operation
  */
-package edu.ie3.datamodel.models
+package edu.ie3.datamodel.models.profile
 
 import edu.ie3.datamodel.exceptions.ParsingException
-import edu.ie3.datamodel.models.profile.BdewStandardLoadProfile
-import edu.ie3.datamodel.models.profile.LoadProfile
-import edu.ie3.datamodel.models.profile.NbwTemperatureDependantLoadProfile
-import edu.ie3.datamodel.models.profile.StandardLoadProfile
-import edu.ie3.datamodel.models.profile.TemperatureDependantLoadProfile
 import spock.lang.Specification
 
 class LoadProfileTest extends Specification {
@@ -189,6 +184,6 @@ class LoadProfileTest extends Specification {
 
 		then:
 		def e = thrown(ParsingException)
-		e.message == "Cannot parse \"not_a_key\" to a valid known load profile"
+		e.message == "No predefined load profile with key 'not_a_key' found. Please provide one of the following keys: h0, l0, l1, l2, g0, g1, g2, g3, g4, g5, g6, ep1, ez2"
 	}
 }


### PR DESCRIPTION
Resolves #607 

Builds on contributions of #608 by @t-ober 


At some point, when the number of load profiles grows, we should consider caching the profiles returned by `getAllProfiles()`. For now, I think it's fine the way it is.