### PR TITLE
Fixing naming of heat pump result in documentation.

### DIFF
--- a/docs/readthedocs/models/result/participant/hp.rst
+++ b/docs/readthedocs/models/result/participant/hp.rst
@@ -1,6 +1,6 @@
 .. _hp_result:
 
-Load
+Heat Pump
 ----
 Result of a heat pump.
 


### PR DESCRIPTION
Resolves #729 