### PR TITLE
Fixing sometimes failing tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- Fixed Couchbase integration tests that randomly failed [#755](https://github.com/ie3-institute/PowerSystemDataModel/issues/755)
 
 ### Changed
 - Changing from comparing strings to comparing uuids in `EntitySource.findFirstEntityByUuid` [#829](https://github.com/ie3-institute/PowerSystemDataModel/issues/829)

--- a/src/main/java/edu/ie3/datamodel/io/connectors/CouchbaseConnector.java
+++ b/src/main/java/edu/ie3/datamodel/io/connectors/CouchbaseConnector.java
@@ -8,10 +8,12 @@ package edu.ie3.datamodel.io.connectors;
 import com.couchbase.client.core.diagnostics.PingResult;
 import com.couchbase.client.java.AsyncCollection;
 import com.couchbase.client.java.Cluster;
+import com.couchbase.client.java.ClusterOptions;
 import com.couchbase.client.java.Collection;
 import com.couchbase.client.java.kv.GetResult;
 import com.couchbase.client.java.kv.MutationResult;
 import com.couchbase.client.java.query.QueryResult;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -34,6 +36,24 @@ public class CouchbaseConnector implements DataConnector {
   public CouchbaseConnector(String url, String bucketName, String username, String password) {
     this.bucketName = bucketName;
     cluster = Cluster.connect(url, username, password);
+  }
+
+  /**
+   * Initializes a new CouchbaseConnector with given KV timeout
+   *
+   * @param url the url to the cluster
+   * @param bucketName the name of the bucket to connect to
+   * @param username the user name
+   * @param password the user password
+   * @param kvTimeout the key-value access timeout
+   */
+  public CouchbaseConnector(
+      String url, String bucketName, String username, String password, Duration kvTimeout) {
+    this.bucketName = bucketName;
+    ClusterOptions clusterOptions =
+        ClusterOptions.clusterOptions(username, password)
+            .environment(env -> env.timeoutConfig(to -> to.kvTimeout(kvTimeout)));
+    cluster = Cluster.connect(url, clusterOptions);
   }
 
   /**

--- a/src/test/groovy/edu/ie3/datamodel/io/factory/result/SystemParticipantResultFactoryTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/factory/result/SystemParticipantResultFactoryTest.groovy
@@ -156,13 +156,13 @@ class SystemParticipantResultFactoryTest extends Specification implements Factor
       "p"         : "2",
       "q"         : "2",
     ]
-    expect: "that the factory should not need more than 2 seconds for processing 100.000 entities"
+    expect: "that the factory should not need more than 3 seconds for processing 10.000 entities"
     Long startTime = System.currentTimeMillis()
     10000.times {
       resultFactory.get(new SimpleEntityData(parameter, StorageResult))
     }
     BigDecimal elapsedTime = (System
         .currentTimeMillis() - startTime) / 1000.0
-    elapsedTime < 2
+    elapsedTime < 3
   }
 }

--- a/src/test/groovy/edu/ie3/datamodel/io/source/couchbase/CouchbaseWeatherSourceCosmoIT.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/source/couchbase/CouchbaseWeatherSourceCosmoIT.groovy
@@ -23,6 +23,7 @@ import org.testcontainers.utility.MountableFile
 import spock.lang.Shared
 import spock.lang.Specification
 
+import java.time.Duration
 import java.time.ZoneId
 
 @Testcontainers
@@ -64,7 +65,13 @@ class CouchbaseWeatherSourceCosmoIT extends Specification implements TestContain
         "--generate-key", "weather::%" + coordinateIdColumnName + "%::%time%",
         "--dataset", "file:///home/weather_cosmo.json")
 
-    def connector = new CouchbaseConnector(couchbaseContainer.connectionString, bucketDefinition.name, couchbaseContainer.username, couchbaseContainer.password)
+    // increased timeout to deal with CI under high load
+    def connector = new CouchbaseConnector(
+        couchbaseContainer.connectionString,
+        bucketDefinition.name,
+        couchbaseContainer.username,
+        couchbaseContainer.password,
+        Duration.ofSeconds(20))
     def dtfPattern = "yyyy-MM-dd'T'HH:mm:ssxxx"
     def weatherFactory = new CosmoTimeBasedWeatherValueFactory(new TimeUtil(ZoneId.of("UTC"), Locale.GERMANY, dtfPattern))
     source = new CouchbaseWeatherSource(connector, CosmoWeatherTestData.coordinateSource, coordinateIdColumnName, weatherFactory, dtfPattern)

--- a/src/test/groovy/edu/ie3/datamodel/io/source/couchbase/CouchbaseWeatherSourceCosmoIT.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/source/couchbase/CouchbaseWeatherSourceCosmoIT.groovy
@@ -36,7 +36,7 @@ class CouchbaseWeatherSourceCosmoIT extends Specification implements TestContain
   CouchbaseContainer couchbaseContainer = new CouchbaseContainer("couchbase/server:6.6.0")
   .withBucket(bucketDefinition)
   .withExposedPorts(8091, 8092, 8093, 8094, 11210)
-  .withStartupAttempts(3)
+  .withStartupAttempts(3) // 3 attempts because startup (node renaming) sometimes fails when executed too early
 
   @Shared
   CouchbaseWeatherSource source

--- a/src/test/groovy/edu/ie3/datamodel/io/source/couchbase/CouchbaseWeatherSourceCosmoIT.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/source/couchbase/CouchbaseWeatherSourceCosmoIT.groovy
@@ -32,9 +32,10 @@ class CouchbaseWeatherSourceCosmoIT extends Specification implements TestContain
   BucketDefinition bucketDefinition = new BucketDefinition("ie3_in")
 
   @Shared
-  CouchbaseContainer couchbaseContainer = new CouchbaseContainer("couchbase/server:6.0.2")
+  CouchbaseContainer couchbaseContainer = new CouchbaseContainer("couchbase/server:6.6.0")
   .withBucket(bucketDefinition)
   .withExposedPorts(8091, 8092, 8093, 8094, 11210)
+  .withStartupAttempts(3)
 
   @Shared
   CouchbaseWeatherSource source

--- a/src/test/groovy/edu/ie3/datamodel/io/source/couchbase/CouchbaseWeatherSourceIconIT.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/source/couchbase/CouchbaseWeatherSourceIconIT.groovy
@@ -20,6 +20,7 @@ import org.testcontainers.spock.Testcontainers
 import spock.lang.Shared
 import spock.lang.Specification
 
+import java.time.Duration
 import java.time.ZoneId
 
 @Testcontainers
@@ -61,7 +62,13 @@ class CouchbaseWeatherSourceIconIT extends Specification implements TestContaine
         "--generate-key", "weather::%" + coordinateIdColumnName + "%::%time%",
         "--dataset", "file:///home/weather_icon.json")
 
-    def connector = new CouchbaseConnector(couchbaseContainer.connectionString, bucketDefinition.name, couchbaseContainer.username, couchbaseContainer.password)
+    // increased timeout to deal with CI under high load
+    def connector = new CouchbaseConnector(
+        couchbaseContainer.connectionString,
+        bucketDefinition.name,
+        couchbaseContainer.username,
+        couchbaseContainer.password,
+        Duration.ofSeconds(20))
     def dtfPattern = "yyyy-MM-dd'T'HH:mm:ssxxx"
     def weatherFactory = new IconTimeBasedWeatherValueFactory(new TimeUtil(ZoneId.of("UTC"), Locale.GERMANY, dtfPattern))
     source = new CouchbaseWeatherSource(connector, IconWeatherTestData.coordinateSource, coordinateIdColumnName, weatherFactory, dtfPattern)

--- a/src/test/groovy/edu/ie3/datamodel/io/source/couchbase/CouchbaseWeatherSourceIconIT.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/source/couchbase/CouchbaseWeatherSourceIconIT.groovy
@@ -33,7 +33,7 @@ class CouchbaseWeatherSourceIconIT extends Specification implements TestContaine
   CouchbaseContainer couchbaseContainer = new CouchbaseContainer("couchbase/server:6.6.0")
   .withBucket(bucketDefinition)
   .withExposedPorts(8091, 8092, 8093, 8094, 11210)
-  .withStartupAttempts(3)
+  .withStartupAttempts(3) // 3 attempts because startup (node renaming) sometimes fails when executed too early
 
   @Shared
   CouchbaseWeatherSource source

--- a/src/test/groovy/edu/ie3/datamodel/io/source/couchbase/CouchbaseWeatherSourceIconIT.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/source/couchbase/CouchbaseWeatherSourceIconIT.groovy
@@ -29,8 +29,10 @@ class CouchbaseWeatherSourceIconIT extends Specification implements TestContaine
   BucketDefinition bucketDefinition = new BucketDefinition("ie3_in")
 
   @Shared
-  CouchbaseContainer couchbaseContainer = new CouchbaseContainer("couchbase/server:6.0.2").withBucket(bucketDefinition)
+  CouchbaseContainer couchbaseContainer = new CouchbaseContainer("couchbase/server:6.6.0")
+  .withBucket(bucketDefinition)
   .withExposedPorts(8091, 8092, 8093, 8094, 11210)
+  .withStartupAttempts(3)
 
   @Shared
   CouchbaseWeatherSource source


### PR DESCRIPTION
Resolves #755

- Couchbase tests
  - Increased key-value-timeout to fix `GetRequest, Reason: TIMEOUT` fails
  - 3 start attempts to fix `Container startup failed`
- SystemParticipantResultFactoryTest
  - Slighty increased time allowed for writing out results

If you look at CI runs 6-10 (which ran in parallel), random failures should be fixed now (8th run failure was due to result writing taking too long, which I then fixed)

![grafik](https://github.com/ie3-institute/PowerSystemDataModel/assets/14994800/bd1fcb22-79a2-4865-bddd-11384d4cc272)
