### PR TITLE
Fixing bug that prevents `MappingEntries` from getting processed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhancing `VoltageLevel` with `equals` method [#1063](https://github.com/ie3-institute/PowerSystemDataModel/issues/1063)
 
 ### Fixed
+- Fixed `MappingEntryies` not getting processed by adding `Getter` methods for record fields [#1084](https://github.com/ie3-institute/PowerSystemDataModel/issues/1084) 
 
 ### Changed
 - Improvements to the search for corner points in `IdCoordinateSource` [#1016](https://github.com/ie3-institute/PowerSystemDataModel/issues/1016)

--- a/src/main/java/edu/ie3/datamodel/io/source/TimeSeriesMappingSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/TimeSeriesMappingSource.java
@@ -10,6 +10,8 @@ import edu.ie3.datamodel.exceptions.SourceException;
 import edu.ie3.datamodel.io.factory.EntityData;
 import edu.ie3.datamodel.io.factory.timeseries.TimeSeriesMappingFactory;
 import edu.ie3.datamodel.models.input.InputEntity;
+import edu.ie3.datamodel.models.input.system.SystemParticipantInput;
+import edu.ie3.datamodel.models.timeseries.TimeSeries;
 import edu.ie3.datamodel.utils.Try;
 import edu.ie3.datamodel.utils.Try.*;
 import java.util.*;
@@ -74,6 +76,16 @@ public abstract class TimeSeriesMappingSource {
 
   /** Class to represent one entry within the participant to time series mapping */
   public record MappingEntry(UUID participant, UUID timeSeries) implements InputEntity {
+
+    /** Returns the {@link UUID} of the {@link SystemParticipantInput}. */
+    public UUID getParticipant() {
+      return participant;
+    }
+
+    /** Returns the {@link UUID} of the {@link TimeSeries}. */
+    public UUID getTimeSeries() {
+      return timeSeries;
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/src/test/groovy/edu/ie3/datamodel/io/processor/input/InputEntityProcessorTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/processor/input/InputEntityProcessorTest.groovy
@@ -7,6 +7,7 @@ package edu.ie3.datamodel.io.processor.input
 
 import static edu.ie3.util.quantities.PowerSystemUnits.PU
 
+import edu.ie3.datamodel.io.source.TimeSeriesMappingSource
 import edu.ie3.datamodel.models.OperationTime
 import edu.ie3.datamodel.models.StandardUnits
 import edu.ie3.datamodel.models.UniqueEntity
@@ -624,6 +625,23 @@ class InputEntityProcessorTest extends Specification {
 
     then:
     actual == expected
+  }
+
+  def "The InputEntityProcessor should serialize a provided MappingEntry correctly"() {
+    given:
+    def processor = new InputEntityProcessor(TimeSeriesMappingSource.MappingEntry)
+    def validResult = new TimeSeriesMappingSource.MappingEntry(UUID.fromString("7eb7b296-f4c4-4020-acf3-e865453b5dbd"), UUID.fromString("bc581c6c-3044-48a1-aea1-5b2cb1370356"))
+
+    Map expectedResults = [
+      "participant": "7eb7b296-f4c4-4020-acf3-e865453b5dbd",
+      "timeSeries": "bc581c6c-3044-48a1-aea1-5b2cb1370356"
+    ]
+
+    when: "the entity is passed to the processor"
+    def processingResult = processor.handleEntity(validResult)
+
+    then: "make sure that the result is as expected "
+    processingResult == expectedResults
   }
 
   def "The InputEntityProcessor should serialize an entity but ignore the operator field when OperatorInput is equal to NO_OPERATOR_ASSIGNED"() {


### PR DESCRIPTION
Resolves #1084 