### PR TITLE
Implemented auto-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
@@ -58,12 +64,6 @@ jobs:
         env:
           BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
         run: bash scripts/run-version-check.sh
-
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 17
 
       - name: Build Project
         run: ./gradlew --refresh-dependencies clean assemble spotlessCheck

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,24 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'ie3-institute/PowerSystemDataModel'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Implemented GitHub Actions for automatic code integration. [#1237](https://github.com/ie3-institute/PowerSystemDataModel/issues/1237)
 - Added `CopyBuilders` to `Line-/Transformer2W-/Tranformer3WTypeInput` [#1275](https://github.com/ie3-institute/PowerSystemDataModel/issues/1275)
+- Implementing auto-merge for dependabot PRs [#1299](https://github.com/ie3-institute/PowerSystemDataModel/issues/1299)
 
 ### Fixed
 - Fixed SonarQube junit path issue in GitHub Actions [#1284](https://github.com/ie3-institute/PowerSystemDataModel/issues/1284)


### PR DESCRIPTION
Closes #1299 

This pull request includes several changes to the GitHub Actions workflows and updates the `CHANGELOG.md` to reflect these changes. The most important changes include setting up Java earlier in the CI workflow, adding a new workflow for Dependabot auto-merge, and updating the changelog to document these changes.

Changes to GitHub Actions workflows:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR33-R38): Moved the Java setup step to an earlier point in the workflow and removed the duplicate setup step later in the workflow. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR33-R38) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL62-L67)
* [`.github/workflows/dependabot-auto-merge.yml`](diffhunk://#diff-2fe48d1021006468ac63263583b5db615dd5e63a39ebff862cc4e2f06b59caa1R1-R24): Added a new workflow to enable auto-merge for Dependabot pull requests that meet specific criteria.

Documentation updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR12): Added an entry to document the implementation of auto-merge for Dependabot pull requests.