### PR TITLE
Fixed handling of `CongestionResult.InputModelType` in `EntityProcessor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased/Snapshot]
 
+### Fixed
+- Fixed handling of `CongestionResult.InputModelType` in `EntityProcessor` [#1325](https://github.com/ie3-institute/PowerSystemDataModel/issues/1325)
+
 ## [7.0.0] - 2025-05-08
 
 ### Added

--- a/src/main/java/edu/ie3/datamodel/io/processor/Processor.java
+++ b/src/main/java/edu/ie3/datamodel/io/processor/Processor.java
@@ -15,6 +15,7 @@ import edu.ie3.datamodel.models.input.OperatorInput;
 import edu.ie3.datamodel.models.input.connector.SwitchInput;
 import edu.ie3.datamodel.models.input.system.characteristic.CharacteristicInput;
 import edu.ie3.datamodel.models.profile.LoadProfile;
+import edu.ie3.datamodel.models.result.CongestionResult;
 import edu.ie3.datamodel.models.voltagelevels.VoltageLevel;
 import edu.ie3.datamodel.utils.Try;
 import edu.ie3.datamodel.utils.Try.*;
@@ -293,6 +294,8 @@ public abstract class Processor<T> {
           "ReactivePowerCharacteristic",
           "CharacteristicInput" -> resultStringBuilder.append(
           ((CharacteristicInput<?, ?>) methodReturnObject).serialize());
+      case "InputModelType" -> resultStringBuilder.append(
+          ((CongestionResult.InputModelType) methodReturnObject).type);
       default -> throw new EntityProcessorException(
           "Unable to process value for attribute/field '"
               + fieldName

--- a/src/test/groovy/edu/ie3/datamodel/io/processor/result/ResultEntityProcessorTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/processor/result/ResultEntityProcessorTest.groovy
@@ -7,6 +7,7 @@ package edu.ie3.datamodel.io.processor.result
 
 import edu.ie3.datamodel.exceptions.EntityProcessorException
 import edu.ie3.datamodel.models.StandardUnits
+import edu.ie3.datamodel.models.result.CongestionResult
 import edu.ie3.datamodel.models.result.NodeResult
 import edu.ie3.datamodel.models.result.ResultEntity
 import edu.ie3.datamodel.models.result.connector.LineResult
@@ -272,6 +273,37 @@ class ResultEntityProcessorTest extends Specification {
 
     when:
     def validProcessedElement = sysPartResProcessor.handleEntity(validResult)
+
+    then:
+    validProcessedElement == expectedResults
+  }
+
+  def "A ResultEntityProcessor should serialize a CongestionResult correctly"() {
+    given:
+    def resultProcessor = new ResultEntityProcessor(CongestionResult)
+
+    def validResult = new CongestionResult(
+        ZonedDateTime.parse("2020-01-30T17:26:44Z"),
+        inputModel,
+        CongestionResult.InputModelType.LINE,
+        3,
+        Quantities.getQuantity(110, Units.PERCENT),
+        Quantities.getQuantity(0, Units.PERCENT),
+        Quantities.getQuantity(100, Units.PERCENT),
+        )
+
+    def expectedResults = [
+      inputModel: '22bea5fc-2cb2-4c61-beb9-b476e0107f52',
+      max       : '100.0',
+      min       : '0.0',
+      subgrid   : '3',
+      time      : '2020-01-30T17:26:44Z',
+      type      : 'line',
+      value     : '110.0'
+    ]
+
+    when:
+    def validProcessedElement = resultProcessor.handleEntity(validResult)
 
     then:
     validProcessedElement == expectedResults


### PR DESCRIPTION
Resolves #1325