### PR TITLE
Extend `GermanVoltageLevelUtils` with more synonymousIds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Updated CI-Pipeline to run task `Deploy` and `Staging` only for `Main` [#1403](https://github.com/ie3-institute/PowerSystemDataModel/issues/1403)
+- Extend `GermanVoltageLevelUtils` with more synonymousIds [#143](https://github.com/ie3-institute/PowerSystemDataModel/issues/143)
 
 ## [8.1.0] - 2025-07-25
 

--- a/src/main/java/edu/ie3/datamodel/models/voltagelevels/GermanVoltageLevelUtils.java
+++ b/src/main/java/edu/ie3/datamodel/models/voltagelevels/GermanVoltageLevelUtils.java
@@ -27,28 +27,28 @@ public class GermanVoltageLevelUtils {
       new CommonVoltageLevel(
           "Niederspannung",
           Quantities.getQuantity(0.4, KILOVOLT),
-          new HashSet<>(Arrays.asList("lv", "ns")),
+          new HashSet<>(Arrays.asList("lv", "ns", "0.4kV")),
           new RightOpenInterval<>(
               Quantities.getQuantity(0d, KILOVOLT), Quantities.getQuantity(10d, KILOVOLT)));
   public static final CommonVoltageLevel MV_10KV =
       new CommonVoltageLevel(
           MS,
           Quantities.getQuantity(10d, KILOVOLT),
-          new HashSet<>(Arrays.asList("ms", "mv", "ms_10kv", "mv_10kV")),
+          new HashSet<>(Arrays.asList("ms", "mv", "ms_10kv", "mv_10kV", "10.0kV", "10kV")),
           new RightOpenInterval<>(
               Quantities.getQuantity(10d, KILOVOLT), Quantities.getQuantity(20d, KILOVOLT)));
   public static final CommonVoltageLevel MV_20KV =
       new CommonVoltageLevel(
           MS,
           Quantities.getQuantity(20d, KILOVOLT),
-          new HashSet<>(Arrays.asList("ms", "mv", "ms_20kv", "mv_20kV")),
+          new HashSet<>(Arrays.asList("ms", "mv", "ms_20kv", "mv_20kV", "20.0kV", "20kV")),
           new RightOpenInterval<>(
               Quantities.getQuantity(20d, KILOVOLT), Quantities.getQuantity(30d, KILOVOLT)));
   public static final CommonVoltageLevel MV_30KV =
       new CommonVoltageLevel(
           MS,
           Quantities.getQuantity(30d, KILOVOLT),
-          new HashSet<>(Arrays.asList("ms", "mv", "ms_30kv", "mv_30kV")),
+          new HashSet<>(Arrays.asList("ms", "mv", "ms_30kv", "mv_30kV", "30.0kV", "30kV")),
           new RightOpenInterval<>(
               Quantities.getQuantity(30d, KILOVOLT), Quantities.getQuantity(110d, KILOVOLT)));
   public static final CommonVoltageLevel HV =

--- a/src/test/groovy/edu/ie3/datamodel/models/GermanVoltageLevelUtilsTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/GermanVoltageLevelUtilsTest.groovy
@@ -24,9 +24,16 @@ class GermanVoltageLevelUtilsTest extends Specification {
     where:
     id      || vRated                                   || expected
     "NS"    || Quantities.getQuantity(0.4d, KILOVOLT)   || LV
+    "0.4kV" || Quantities.getQuantity(0.4d, KILOVOLT)   || LV
+    "10.0kV"|| Quantities.getQuantity(10d, KILOVOLT)    || MV_10KV
+    "10kV"  || Quantities.getQuantity(10d, KILOVOLT)    || MV_10KV
     "MS"    || Quantities.getQuantity(15d, KILOVOLT)    || MV_10KV
     "MS"    || Quantities.getQuantity(20d, KILOVOLT)    || MV_20KV
+    "20.0kV"|| Quantities.getQuantity(20d, KILOVOLT)    || MV_20KV
+    "20kV"  || Quantities.getQuantity(20d, KILOVOLT)    || MV_20KV
     "MS"    || Quantities.getQuantity(35d, KILOVOLT)    || MV_30KV
+    "30.0kV"|| Quantities.getQuantity(30d, KILOVOLT)    || MV_30KV
+    "30kV"  || Quantities.getQuantity(30d, KILOVOLT)    || MV_30KV
     "HS"    || Quantities.getQuantity(110d, KILOVOLT)   || HV
     "HoeS"  || Quantities.getQuantity(220d, KILOVOLT)   || EHV_220KV
     "HoeS"  || Quantities.getQuantity(380d, KILOVOLT)   || EHV_380KV

--- a/src/test/groovy/edu/ie3/datamodel/utils/ContainerUtilsTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/utils/ContainerUtilsTest.groovy
@@ -278,8 +278,8 @@ class ContainerUtilsTest extends Specification {
     InvalidGridException ex = thrown()
     ex.message == "There are 2 voltage levels apparent, although only one is expected. Following voltage levels" +
         " are present: CommonVoltageLevel{id='Mittelspannung', nominalVoltage=10 kV, synonymousIds=" +
-        "[Mittelspannung, ms, ms_10kv, mv, mv_10kV], voltageRange=Interval [10 kV, 20 kV)}, CommonVoltageLevel" +
-        "{id='Mittelspannung', nominalVoltage=20 kV, synonymousIds=[Mittelspannung, ms, ms_20kv, mv, mv_20kV], " +
+        "[10.0kV, 10kV, Mittelspannung, ms, ms_10kv, mv, mv_10kV], voltageRange=Interval [10 kV, 20 kV)}, CommonVoltageLevel" +
+        "{id='Mittelspannung', nominalVoltage=20 kV, synonymousIds=[20.0kV, 20kV, Mittelspannung, ms, ms_20kv, mv, mv_20kV], " +
         "voltageRange=Interval [20 kV, 30 kV)}"
   }
 


### PR DESCRIPTION
resolves #143 