### PR TITLE
Generalize time-series metadata pipeline for CSV/JSON support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added weathersource documentation [#1390](https://github.com/ie3-institute/PowerSystemDataModel/issues/1390)
 - Added standard asset parameter for `3wTransformer` in `ReadTheDocs` [#1417](https://github.com/ie3-institute/PowerSystemDataModel/issues/1417)
+- Added getter sRated for SystemParticipant inputs and updated them in tests in src[#1412](https://github.com/ie3-institute/PowerSystemDataModel/issues/1412)
 
 ### Fixed
 - Fixed small issues in tests [#1400](https://github.com/ie3-institute/PowerSystemDataModel/issues/1400)

--- a/build.gradle
+++ b/build.gradle
@@ -102,16 +102,17 @@ dependencies {
   implementation 'com.couchbase.client:java-client:3.9.1'
   runtimeOnly 'org.postgresql:postgresql:42.7.8' // postgresql jdbc driver required during runtime
 
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2' //needed for json parser
   implementation 'commons-io:commons-io:2.20.0' // I/O functionalities
   implementation 'commons-codec:commons-codec:1.19.0' // needed by commons-compress
   implementation 'org.apache.commons:commons-compress:1.28.0' // I/O functionalities
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
   options.encoding = 'UTF-8'
 }
 
-tasks.withType(Javadoc){
+tasks.withType(Javadoc).configureEach {
   options.encoding = 'UTF-8'
   failOnError = false // TODO: Temp until JavaDoc issues are resolved
 }

--- a/src/main/java/edu/ie3/datamodel/io/csv/CsvIndividualTimeSeriesMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/csv/CsvIndividualTimeSeriesMetaInformation.java
@@ -1,5 +1,5 @@
 /*
- * © 2022. TU Dortmund University,
+ * © 2025. TU Dortmund University,
  * Institute of Energy Systems, Energy Efficiency and Energy Economics,
  * Research group Distribution grid planning and operation
 */

--- a/src/main/java/edu/ie3/datamodel/io/csv/CsvLoadProfileMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/csv/CsvLoadProfileMetaInformation.java
@@ -1,55 +1,22 @@
 /*
- * © 2024. TU Dortmund University,
+ * © 2025. TU Dortmund University,
  * Institute of Energy Systems, Energy Efficiency and Energy Economics,
  * Research group Distribution grid planning and operation
 */
 package edu.ie3.datamodel.io.csv;
 
+import edu.ie3.datamodel.io.file.FileLoadProfileMetaInformation;
+import edu.ie3.datamodel.io.file.FileType;
 import edu.ie3.datamodel.io.naming.timeseries.LoadProfileMetaInformation;
 import java.nio.file.Path;
-import java.util.Objects;
 
-public class CsvLoadProfileMetaInformation extends LoadProfileMetaInformation {
-  private final Path fullFilePath;
-
+public class CsvLoadProfileMetaInformation extends FileLoadProfileMetaInformation {
   public CsvLoadProfileMetaInformation(String profile, Path fullFilePath) {
-    super(profile);
-    this.fullFilePath = fullFilePath;
+    super(profile, fullFilePath, FileType.CSV);
   }
 
   public CsvLoadProfileMetaInformation(
       LoadProfileMetaInformation metaInformation, Path fullFilePath) {
-    this(metaInformation.getProfile(), fullFilePath);
-  }
-
-  public Path getFullFilePath() {
-    return fullFilePath;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (!(o instanceof CsvLoadProfileMetaInformation that)) return false;
-    if (!super.equals(o)) return false;
-    return fullFilePath.equals(that.fullFilePath);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(super.hashCode(), fullFilePath);
-  }
-
-  @Override
-  public String toString() {
-    return "CsvLoadProfileMetaInformation{"
-        + "uuid='"
-        + getUuid()
-        + '\''
-        + ", profile='"
-        + getProfile()
-        + '\''
-        + "fullFilePath="
-        + fullFilePath
-        + '}';
+    super(metaInformation, fullFilePath, FileType.CSV);
   }
 }

--- a/src/main/java/edu/ie3/datamodel/io/file/FileLoadProfileMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/file/FileLoadProfileMetaInformation.java
@@ -1,0 +1,66 @@
+/*
+ * © 2025. TU Dortmund University,
+ * Institute of Energy Systems, Energy Efficiency and Energy Economics,
+ * Research group Distribution grid planning and operation
+*/
+package edu.ie3.datamodel.io.file;
+
+import edu.ie3.datamodel.io.naming.timeseries.LoadProfileMetaInformation;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.UUID;
+
+public class FileLoadProfileMetaInformation extends LoadProfileMetaInformation {
+  private final Path path;
+  private final FileType fileType;
+
+  public FileLoadProfileMetaInformation(String profile, Path path, FileType fileType) {
+    super(profile);
+    this.path = Objects.requireNonNull(path, "path must not be null");
+    this.fileType = Objects.requireNonNull(fileType, "fileType must not be null");
+  }
+
+  public FileLoadProfileMetaInformation(UUID uuid, String profile, Path path, FileType fileType) {
+    super(uuid, profile);
+    this.path = Objects.requireNonNull(path, "path must not be null");
+    this.fileType = Objects.requireNonNull(fileType, "fileType must not be null");
+  }
+
+  public FileLoadProfileMetaInformation(
+      LoadProfileMetaInformation metaInformation, Path path, FileType fileType) {
+    this(metaInformation.getUuid(), metaInformation.getProfile(), path, fileType);
+  }
+
+  public Path getPath() {
+    return path;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof FileLoadProfileMetaInformation that)) return false;
+    if (!super.equals(o)) return false;
+    return path.equals(that.path) && fileType == that.fileType;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), path, fileType);
+  }
+
+  @Override
+  public String toString() {
+    return "FileLoadProfileMetaInformation{"
+        + "uuid='"
+        + getUuid()
+        + '\''
+        + ", profile='"
+        + getProfile()
+        + '\''
+        + ", path="
+        + path
+        + ", fileType="
+        + fileType
+        + '}';
+  }
+}

--- a/src/main/java/edu/ie3/datamodel/io/file/FileLoadProfileMetaInformation.java
+++ b/src/main/java/edu/ie3/datamodel/io/file/FileLoadProfileMetaInformation.java
@@ -35,6 +35,10 @@ public class FileLoadProfileMetaInformation extends LoadProfileMetaInformation {
     return path;
   }
 
+  public FileType getFileType() {
+    return fileType;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;

--- a/src/main/java/edu/ie3/datamodel/io/file/FileTimeSeriesParserFactory.java
+++ b/src/main/java/edu/ie3/datamodel/io/file/FileTimeSeriesParserFactory.java
@@ -1,0 +1,32 @@
+/*
+ * © 2025. TU Dortmund University,
+ * Institute of Energy Systems, Energy Efficiency and Energy Economics,
+ * Research group Distribution grid planning and operation
+*/
+package edu.ie3.datamodel.io.file;
+
+import edu.ie3.datamodel.io.file.csv.CsvTimeSeriesMappingParser;
+import edu.ie3.datamodel.io.file.csv.CsvTimeSeriesMetaInformationParser;
+import edu.ie3.datamodel.io.file.json.JsonTimeSeriesMappingParser;
+import edu.ie3.datamodel.io.file.json.JsonTimeSeriesMetaInformationParser;
+import edu.ie3.datamodel.io.naming.FileNamingStrategy;
+import java.nio.file.Path;
+
+public class FileTimeSeriesParserFactory {
+
+  public TimeSeriesMetaInformationParser metaInformationParser(
+      Path path, FileType fileType, FileNamingStrategy fileNamingStrategy, String csvSeparator) {
+    return switch (fileType) {
+      case CSV -> new CsvTimeSeriesMetaInformationParser(path, fileNamingStrategy, csvSeparator);
+      case JSON -> new JsonTimeSeriesMetaInformationParser(path, fileNamingStrategy);
+    };
+  }
+
+  public TimeSeriesMappingParser mappingParser(
+      Path path, FileType fileType, FileNamingStrategy fileNamingStrategy, String csvSeparator) {
+    return switch (fileType) {
+      case CSV -> new CsvTimeSeriesMappingParser(path, fileNamingStrategy, csvSeparator);
+      case JSON -> new JsonTimeSeriesMappingParser(path, fileNamingStrategy);
+    };
+  }
+}

--- a/src/main/java/edu/ie3/datamodel/io/file/FileType.java
+++ b/src/main/java/edu/ie3/datamodel/io/file/FileType.java
@@ -1,0 +1,18 @@
+/*
+ * © 2025. TU Dortmund University,
+ * Institute of Energy Systems, Energy Efficiency and Energy Economics,
+ * Research group Distribution grid planning and operation
+*/
+package edu.ie3.datamodel.io.file;
+
+public enum FileType {
+  CSV,
+  JSON;
+
+  public String extension() {
+    return switch (this) {
+      case CSV -> ".csv";
+      case JSON -> ".json";
+    };
+  }
+}

--- a/src/main/java/edu/ie3/datamodel/io/file/TimeSeriesMappingParser.java
+++ b/src/main/java/edu/ie3/datamodel/io/file/TimeSeriesMappingParser.java
@@ -1,0 +1,18 @@
+/*
+ * © 2025. TU Dortmund University,
+ * Institute of Energy Systems, Energy Efficiency and Energy Economics,
+ * Research group Distribution grid planning and operation
+*/
+package edu.ie3.datamodel.io.file;
+
+import edu.ie3.datamodel.exceptions.SourceException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+public interface TimeSeriesMappingParser {
+  Stream<Map<String, String>> parse() throws SourceException;
+
+  Optional<Set<String>> availableFields() throws SourceException;
+}

--- a/src/main/java/edu/ie3/datamodel/io/file/TimeSeriesMetaInformationParser.java
+++ b/src/main/java/edu/ie3/datamodel/io/file/TimeSeriesMetaInformationParser.java
@@ -1,0 +1,21 @@
+/*
+ * © 2025. TU Dortmund University,
+ * Institute of Energy Systems, Energy Efficiency and Energy Economics,
+ * Research group Distribution grid planning and operation
+*/
+package edu.ie3.datamodel.io.file;
+
+import edu.ie3.datamodel.exceptions.SourceException;
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme;
+import edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation;
+import edu.ie3.datamodel.models.profile.LoadProfile;
+import java.util.Map;
+import java.util.UUID;
+
+public interface TimeSeriesMetaInformationParser {
+  Map<UUID, IndividualTimeSeriesMetaInformation> parseIndividualTimeSeriesMetaInformation(
+      ColumnScheme... columnSchemes) throws SourceException;
+
+  Map<String, FileLoadProfileMetaInformation> parseLoadProfileMetaInformation(
+      LoadProfile... profiles) throws SourceException;
+}

--- a/src/main/java/edu/ie3/datamodel/io/file/csv/CsvTimeSeriesMappingParser.java
+++ b/src/main/java/edu/ie3/datamodel/io/file/csv/CsvTimeSeriesMappingParser.java
@@ -1,0 +1,45 @@
+/*
+ * © 2025. TU Dortmund University,
+ * Institute of Energy Systems, Energy Efficiency and Energy Economics,
+ * Research group Distribution grid planning and operation
+*/
+package edu.ie3.datamodel.io.file.csv;
+
+import edu.ie3.datamodel.exceptions.SourceException;
+import edu.ie3.datamodel.io.file.TimeSeriesMappingParser;
+import edu.ie3.datamodel.io.naming.FileNamingStrategy;
+import edu.ie3.datamodel.io.source.TimeSeriesMappingSource;
+import edu.ie3.datamodel.io.source.csv.CsvDataSource;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+public class CsvTimeSeriesMappingParser implements TimeSeriesMappingParser {
+
+  private final CsvDataSource dataSource;
+
+  public CsvTimeSeriesMappingParser(
+      Path path, FileNamingStrategy fileNamingStrategy, String csvSeparator) {
+    Objects.requireNonNull(path, "path must not be null");
+    Objects.requireNonNull(fileNamingStrategy, "fileNamingStrategy must not be null");
+    Objects.requireNonNull(csvSeparator, "csvSeparator must not be null");
+    this.dataSource = new CsvDataSource(csvSeparator, path, fileNamingStrategy);
+  }
+
+  @Override
+  public Stream<Map<String, String>> parse() throws SourceException {
+    return dataSource.getSourceData(TimeSeriesMappingSource.MappingEntry.class);
+  }
+
+  @Override
+  public Optional<Set<String>> availableFields() throws SourceException {
+    return dataSource.getSourceFields(TimeSeriesMappingSource.MappingEntry.class);
+  }
+
+  public CsvDataSource getDataSource() {
+    return dataSource;
+  }
+}

--- a/src/main/java/edu/ie3/datamodel/io/file/csv/CsvTimeSeriesMetaInformationParser.java
+++ b/src/main/java/edu/ie3/datamodel/io/file/csv/CsvTimeSeriesMetaInformationParser.java
@@ -1,0 +1,54 @@
+/*
+ * © 2025. TU Dortmund University,
+ * Institute of Energy Systems, Energy Efficiency and Energy Economics,
+ * Research group Distribution grid planning and operation
+*/
+package edu.ie3.datamodel.io.file.csv;
+
+import edu.ie3.datamodel.exceptions.SourceException;
+import edu.ie3.datamodel.io.file.FileLoadProfileMetaInformation;
+import edu.ie3.datamodel.io.file.TimeSeriesMetaInformationParser;
+import edu.ie3.datamodel.io.naming.FileNamingStrategy;
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme;
+import edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation;
+import edu.ie3.datamodel.io.source.csv.CsvDataSource;
+import edu.ie3.datamodel.models.profile.LoadProfile;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+public class CsvTimeSeriesMetaInformationParser implements TimeSeriesMetaInformationParser {
+
+  private final CsvDataSource dataSource;
+
+  public CsvTimeSeriesMetaInformationParser(
+      Path path, FileNamingStrategy fileNamingStrategy, String csvSeparator) {
+    Objects.requireNonNull(path, "path must not be null");
+    Objects.requireNonNull(fileNamingStrategy, "fileNamingStrategy must not be null");
+    Objects.requireNonNull(csvSeparator, "csvSeparator must not be null");
+    this.dataSource = new CsvDataSource(csvSeparator, path, fileNamingStrategy);
+  }
+
+  @Override
+  public Map<UUID, IndividualTimeSeriesMetaInformation> parseIndividualTimeSeriesMetaInformation(
+      ColumnScheme... columnSchemes) throws SourceException {
+    Map<UUID, ? extends IndividualTimeSeriesMetaInformation> csvMetaInformation =
+        dataSource.getCsvIndividualTimeSeriesMetaInformation(columnSchemes);
+    return csvMetaInformation.entrySet().stream()
+        .collect(
+            java.util.stream.Collectors.toUnmodifiableMap(
+                Map.Entry::getKey,
+                entry -> (IndividualTimeSeriesMetaInformation) entry.getValue()));
+  }
+
+  @Override
+  public Map<String, FileLoadProfileMetaInformation> parseLoadProfileMetaInformation(
+      LoadProfile... profiles) throws SourceException {
+    return dataSource.getLoadProfileMetaInformation(profiles);
+  }
+
+  public CsvDataSource getDataSource() {
+    return dataSource;
+  }
+}

--- a/src/main/java/edu/ie3/datamodel/io/file/json/JsonTimeSeriesMappingParser.java
+++ b/src/main/java/edu/ie3/datamodel/io/file/json/JsonTimeSeriesMappingParser.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
 public class JsonTimeSeriesMappingParser implements TimeSeriesMappingParser {
 
   private static final String SUPPORTED_SCHEMA = "simonaMarkovLoad:psdm:1.0";
+  private static final String ATTRIBUTE_KEY = "attribute";
 
   private final Path basePath;
   private final FileNamingStrategy fileNamingStrategy;
@@ -60,7 +61,7 @@ public class JsonTimeSeriesMappingParser implements TimeSeriesMappingParser {
       return Optional.empty();
     }
     if (result.entries().isEmpty()) {
-      return Optional.of(Set.of("asset", "timeSeries", "targetType", "attribute"));
+      return Optional.of(Set.of("asset", "timeSeries", "targetType", ATTRIBUTE_KEY));
     }
     Set<String> fields =
         result.entries().stream()
@@ -105,7 +106,7 @@ public class JsonTimeSeriesMappingParser implements TimeSeriesMappingParser {
       entry.put("asset", requireText(mappingNode, "target_id", relative));
       entry.put("timeSeries", requireText(mappingNode, "time_series_id", relative));
       entry.put("targetType", requireText(mappingNode, "target_type", relative));
-      entry.put("attribute", requireText(mappingNode, "attribute", relative));
+      entry.put(ATTRIBUTE_KEY, requireText(mappingNode, ATTRIBUTE_KEY, relative));
       entries.add(entry);
     }
 

--- a/src/main/java/edu/ie3/datamodel/io/file/json/JsonTimeSeriesMappingParser.java
+++ b/src/main/java/edu/ie3/datamodel/io/file/json/JsonTimeSeriesMappingParser.java
@@ -1,0 +1,149 @@
+/*
+ * © 2025. TU Dortmund University,
+ * Institute of Energy Systems, Energy Efficiency and Energy Economics,
+ * Research group Distribution grid planning and operation
+*/
+package edu.ie3.datamodel.io.file.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import edu.ie3.datamodel.exceptions.SourceException;
+import edu.ie3.datamodel.io.file.FileType;
+import edu.ie3.datamodel.io.file.TimeSeriesMappingParser;
+import edu.ie3.datamodel.io.naming.FileNamingStrategy;
+import edu.ie3.datamodel.io.source.TimeSeriesMappingSource;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class JsonTimeSeriesMappingParser implements TimeSeriesMappingParser {
+
+  private static final String SUPPORTED_SCHEMA = "simonaMarkovLoad:psdm:1.0";
+
+  private final Path basePath;
+  private final FileNamingStrategy fileNamingStrategy;
+  private final ObjectMapper objectMapper;
+
+  public JsonTimeSeriesMappingParser(Path path, FileNamingStrategy fileNamingStrategy) {
+    this(path, fileNamingStrategy, new ObjectMapper());
+  }
+
+  JsonTimeSeriesMappingParser(
+      Path path, FileNamingStrategy fileNamingStrategy, ObjectMapper objectMapper) {
+    this.basePath = Objects.requireNonNull(path, "path must not be null");
+    this.fileNamingStrategy =
+        Objects.requireNonNull(fileNamingStrategy, "fileNamingStrategy must not be null");
+    this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper must not be null");
+  }
+
+  @Override
+  public Stream<Map<String, String>> parse() throws SourceException {
+    return loadMappings().entries().stream();
+  }
+
+  @Override
+  public Optional<Set<String>> availableFields() throws SourceException {
+    MappingLoadResult result = loadMappings();
+    if (!result.filePresent()) {
+      return Optional.empty();
+    }
+    if (result.entries().isEmpty()) {
+      return Optional.of(Set.of("asset", "timeSeries", "targetType", "attribute"));
+    }
+    Set<String> fields =
+        result.entries().stream()
+            .flatMap(entry -> entry.keySet().stream())
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+    return Optional.of(fields);
+  }
+
+  private MappingLoadResult loadMappings() throws SourceException {
+    Path relative =
+        fileNamingStrategy
+            .getFilePath(TimeSeriesMappingSource.MappingEntry.class)
+            .orElseThrow(
+                () ->
+                    new SourceException(
+                        "Unable to determine path to time series mapping file for JSON parsing."));
+    Path file = basePath.resolve(relative.toString() + FileType.JSON.extension());
+    if (!Files.exists(file)) {
+      return new MappingLoadResult(Collections.emptyList(), false);
+    }
+
+    JsonNode root = readJson(relative, file);
+    String schema = requireText(root, "schema", relative);
+    if (!SUPPORTED_SCHEMA.equals(schema)) {
+      throw new SourceException(
+          "Unsupported schema '"
+              + schema
+              + "' in '"
+              + relative
+              + "'. Expected '"
+              + SUPPORTED_SCHEMA
+              + "'.");
+    }
+
+    ArrayNode mappings = requireArray(root, "mappings", relative);
+    List<Map<String, String>> entries = new ArrayList<>(mappings.size());
+    for (JsonNode mappingNode : mappings) {
+      if (!mappingNode.isObject()) {
+        throw new SourceException("Found non-object mapping entry in '" + relative + "'.");
+      }
+      Map<String, String> entry = new LinkedHashMap<>();
+      entry.put("asset", requireText(mappingNode, "target_id", relative));
+      entry.put("timeSeries", requireText(mappingNode, "time_series_id", relative));
+      entry.put("targetType", requireText(mappingNode, "target_type", relative));
+      entry.put("attribute", requireText(mappingNode, "attribute", relative));
+      entries.add(entry);
+    }
+
+    return new MappingLoadResult(entries, true);
+  }
+
+  private JsonNode readJson(Path relative, Path file) throws SourceException {
+    try {
+      return objectMapper.readTree(file.toFile());
+    } catch (IOException e) {
+      throw new SourceException("Unable to read mapping file '" + relative + "'.", e);
+    }
+  }
+
+  private ArrayNode requireArray(JsonNode parent, String field, Path relative)
+      throws SourceException {
+    JsonNode node = requireNode(parent, field, relative);
+    if (!node.isArray()) {
+      throw new SourceException("Field '" + field + "' in '" + relative + "' must be an array.");
+    }
+    return (ArrayNode) node;
+  }
+
+  private String requireText(JsonNode parent, String field, Path relative) throws SourceException {
+    JsonNode node = requireNode(parent, field, relative);
+    if (!node.isTextual()) {
+      throw new SourceException("Field '" + field + "' in '" + relative + "' must be textual.");
+    }
+    return node.asText();
+  }
+
+  private JsonNode requireNode(JsonNode parent, String field, Path relative)
+      throws SourceException {
+    if (!parent.has(field)) {
+      throw new SourceException("Missing field '" + field + "' in '" + relative + "'.");
+    }
+    return parent.get(field);
+  }
+
+  private record MappingLoadResult(List<Map<String, String>> entries, boolean filePresent) {}
+}

--- a/src/main/java/edu/ie3/datamodel/io/file/json/JsonTimeSeriesMetaInformationParser.java
+++ b/src/main/java/edu/ie3/datamodel/io/file/json/JsonTimeSeriesMetaInformationParser.java
@@ -1,0 +1,582 @@
+/*
+ * © 2025. TU Dortmund University,
+ * Institute of Energy Systems, Energy Efficiency and Energy Economics,
+ * Research group Distribution grid planning and operation
+*/
+package edu.ie3.datamodel.io.file.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import edu.ie3.datamodel.exceptions.SourceException;
+import edu.ie3.datamodel.io.file.FileLoadProfileMetaInformation;
+import edu.ie3.datamodel.io.file.FileType;
+import edu.ie3.datamodel.io.file.TimeSeriesMetaInformationParser;
+import edu.ie3.datamodel.io.naming.FileNamingStrategy;
+import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme;
+import edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation;
+import edu.ie3.datamodel.io.naming.timeseries.LoadProfileMetaInformation;
+import edu.ie3.datamodel.models.profile.LoadProfile;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class JsonTimeSeriesMetaInformationParser implements TimeSeriesMetaInformationParser {
+
+  private static final String SUPPORTED_SCHEMA = "simonaMarkovLoad:psdm:1.0";
+
+  private final Path basePath;
+  private final FileNamingStrategy fileNamingStrategy;
+  private final ObjectMapper objectMapper;
+
+  public JsonTimeSeriesMetaInformationParser(Path path, FileNamingStrategy fileNamingStrategy) {
+    this.basePath = Objects.requireNonNull(path, "path must not be null");
+    this.fileNamingStrategy =
+        Objects.requireNonNull(fileNamingStrategy, "fileNamingStrategy must not be null");
+    this.objectMapper = new ObjectMapper();
+  }
+
+  @Override
+  public Map<UUID, IndividualTimeSeriesMetaInformation> parseIndividualTimeSeriesMetaInformation(
+      ColumnScheme... columnSchemes) {
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public Map<String, FileLoadProfileMetaInformation> parseLoadProfileMetaInformation(
+      LoadProfile... profiles) throws SourceException {
+    List<Path> loadProfileFiles =
+        findMatchingFiles(fileNamingStrategy.getLoadProfileTimeSeriesPattern());
+
+    Map<String, FileLoadProfileMetaInformation> result = new HashMap<>(loadProfileFiles.size());
+    for (Path relativeFile : loadProfileFiles) {
+      Path absoluteFile = basePath.resolve(relativeFile);
+      JsonNode root = readJson(relativeFile, absoluteFile);
+      JsonMetadata metadata = validateMetadata(relativeFile, root);
+
+      LoadProfileMetaInformation namingMeta =
+          fileNamingStrategy.loadProfileTimeSeriesMetaInformation(relativeFile.toString());
+
+      if (!metadata.seriesId().equals(namingMeta.getProfile())) {
+        throw new SourceException(
+            "Series id '"
+                + metadata.seriesId()
+                + "' in '"
+                + relativeFile
+                + "' does not match expected profile '"
+                + namingMeta.getProfile()
+                + "'.");
+      }
+
+      if (!matchesRequestedProfiles(profiles, namingMeta.getProfile())) {
+        continue;
+      }
+
+      Path relativeWithoutEnding =
+          Path.of(FileNamingStrategy.removeFileNameEnding(relativeFile.toString()));
+
+      FileLoadProfileMetaInformation fileMeta =
+          new FileLoadProfileMetaInformation(namingMeta, relativeWithoutEnding, FileType.JSON);
+
+      FileLoadProfileMetaInformation previous = result.put(fileMeta.getProfile(), fileMeta);
+      if (previous != null) {
+        throw new SourceException(
+            "Multiple JSON definitions detected for load profile '" + fileMeta.getProfile() + "'.");
+      }
+    }
+
+    return result;
+  }
+
+  private boolean matchesRequestedProfiles(LoadProfile[] profiles, String profileKey) {
+    if (profiles == null || profiles.length == 0) {
+      return true;
+    }
+    return Arrays.stream(profiles).anyMatch(profile -> profile.getKey().equals(profileKey));
+  }
+
+  private List<Path> findMatchingFiles(Pattern pattern) throws SourceException {
+    try (Stream<Path> stream = Files.walk(basePath)) {
+      return stream
+          .filter(Files::isRegularFile)
+          .filter(path -> path.getFileName().toString().endsWith(FileType.JSON.extension()))
+          .map(basePath::relativize)
+          .filter(
+              relative ->
+                  pattern
+                      .matcher(FileNamingStrategy.removeFileNameEnding(relative.toString()))
+                      .matches())
+          .collect(Collectors.toList());
+    } catch (IOException e) {
+      throw new SourceException("Unable to inspect directory '" + basePath + "'.", e);
+    }
+  }
+
+  private JsonNode readJson(Path relativeFile, Path absoluteFile) throws SourceException {
+    try {
+      return objectMapper.readTree(absoluteFile.toFile());
+    } catch (IOException e) {
+      throw new SourceException(
+          "Unable to read JSON meta information from '" + relativeFile + "'.", e);
+    }
+  }
+
+  private JsonMetadata validateMetadata(Path relativeFile, JsonNode root) throws SourceException {
+    String schema = requireText(root, "schema", relativeFile);
+    if (!SUPPORTED_SCHEMA.equals(schema)) {
+      throw new SourceException(
+          "Unsupported schema '"
+              + schema
+              + "' in '"
+              + relativeFile
+              + "'. Expected '"
+              + SUPPORTED_SCHEMA
+              + "'.");
+    }
+
+    JsonNode generator = requireObject(root, "generator", relativeFile);
+    requireText(generator, "name", relativeFile);
+    requireText(generator, "version", relativeFile);
+    JsonNode generatorConfig = requireObject(generator, "config", relativeFile);
+    int nStates = requirePositiveInt(generatorConfig, "n_states", relativeFile);
+    double laplaceAlpha = requireDouble(generatorConfig, "laplace_alpha", relativeFile);
+    if (laplaceAlpha < 0d) {
+      throw new SourceException(
+          "laplace_alpha must be >= 0 in '" + relativeFile + "' but was " + laplaceAlpha + ".");
+    }
+
+    JsonNode timeModel = requireObject(root, "time_model", relativeFile);
+    int bucketCount = requirePositiveInt(timeModel, "bucket_count", relativeFile);
+    JsonNode bucketEncoding = requireObject(timeModel, "bucket_encoding", relativeFile);
+    requireText(bucketEncoding, "formula", relativeFile);
+    int samplingInterval = requirePositiveInt(timeModel, "sampling_interval_minutes", relativeFile);
+    String timezone = requireText(timeModel, "timezone", relativeFile);
+
+    JsonNode valueModel = requireObject(root, "value_model", relativeFile);
+    String valueUnit = requireText(valueModel, "value_unit", relativeFile);
+    JsonNode normalization = requireObject(valueModel, "normalization", relativeFile);
+    requireText(normalization, "method", relativeFile);
+    JsonNode discretization = requireObject(valueModel, "discretization", relativeFile);
+    int discretizationStates = requirePositiveInt(discretization, "states", relativeFile);
+    ArrayNode thresholdsRight = requireArray(discretization, "thresholds_right", relativeFile);
+    if (thresholdsRight.isEmpty()) {
+      throw new SourceException(
+          "value_model.discretization.thresholds_right must not be empty in '"
+              + relativeFile
+              + "'.");
+    }
+    thresholdsRight.forEach(
+        node -> {
+          if (!node.isNumber()) {
+            throw new IllegalStateException(
+                "Non-numeric entry in thresholds_right of '" + relativeFile + "'.");
+          }
+        });
+
+    JsonNode parameters = requireObject(root, "parameters", relativeFile);
+    JsonNode transitionsParam = requireObject(parameters, "transitions", relativeFile);
+    requireText(transitionsParam, "empty_row_strategy", relativeFile);
+    requireObject(parameters, "gmm", relativeFile);
+
+    JsonNode series = requireObject(root, "series", relativeFile);
+    String seriesId = requireText(series, "id", relativeFile);
+    requireText(series, "display_name", relativeFile);
+    String seriesUnit = requireText(series, "unit", relativeFile);
+    String seriesTimezone = requireText(series, "timezone", relativeFile);
+    int seriesSampling = requirePositiveInt(series, "sampling_interval_minutes", relativeFile);
+    int seriesStates = requirePositiveInt(series, "n_states", relativeFile);
+    JsonNode dataRef = requireObject(series, "data_ref", relativeFile);
+    requireText(dataRef, "type", relativeFile);
+    boolean transitionsInline = requireBoolean(dataRef, "transitions", relativeFile);
+    boolean gmmsInline = requireBoolean(dataRef, "gmms", relativeFile);
+
+    if (!seriesUnit.equals(valueUnit)) {
+      throw new SourceException(
+          "series.unit '"
+              + seriesUnit
+              + "' does not match value_model.value_unit '"
+              + valueUnit
+              + "' in '"
+              + relativeFile
+              + "'.");
+    }
+    if (!seriesTimezone.equals(timezone)) {
+      throw new SourceException(
+          "series.timezone '"
+              + seriesTimezone
+              + "' does not match time_model.timezone '"
+              + timezone
+              + "' in '"
+              + relativeFile
+              + "'.");
+    }
+    if (seriesSampling != samplingInterval) {
+      throw new SourceException(
+          "series.sampling_interval_minutes "
+              + seriesSampling
+              + " does not match time_model.sampling_interval_minutes "
+              + samplingInterval
+              + " in '"
+              + relativeFile
+              + "'.");
+    }
+    if (seriesStates != nStates) {
+      throw new SourceException(
+          "series.n_states "
+              + seriesStates
+              + " does not match generator.config.n_states "
+              + nStates
+              + " in '"
+              + relativeFile
+              + "'.");
+    }
+    if (discretizationStates != nStates) {
+      throw new SourceException(
+          "value_model.discretization.states "
+              + discretizationStates
+              + " does not match generator.config.n_states "
+              + nStates
+              + " in '"
+              + relativeFile
+              + "'.");
+    }
+    if (!transitionsInline || !gmmsInline) {
+      throw new SourceException(
+          "data_ref for '" + relativeFile + "' must declare transitions and gmms as inline.");
+    }
+
+    JsonNode data = requireObject(root, "data", relativeFile);
+    JsonNode transitions = requireObject(data, "transitions", relativeFile);
+    ArrayNode shape = requireArray(transitions, "shape", relativeFile);
+    if (shape.size() != 3) {
+      throw new SourceException(
+          "data.transitions.shape must contain exactly three elements in '" + relativeFile + "'.");
+    }
+    int shapeBuckets = requirePositiveInt(shape, 0, relativeFile, "data.transitions.shape");
+    int shapeStatesRows = requirePositiveInt(shape, 1, relativeFile, "data.transitions.shape");
+    int shapeStatesCols = requirePositiveInt(shape, 2, relativeFile, "data.transitions.shape");
+
+    if (shapeBuckets != bucketCount || shapeStatesRows != nStates || shapeStatesCols != nStates) {
+      throw new SourceException(
+          "data.transitions.shape "
+              + shape
+              + " does not match bucket_count or n_states in '"
+              + relativeFile
+              + "'.");
+    }
+
+    String dtype = requireText(transitions, "dtype", relativeFile);
+    if (!"float32".equals(dtype)) {
+      throw new SourceException(
+          "data.transitions.dtype must be 'float32' in '" + relativeFile + "'.");
+    }
+    String encoding = requireText(transitions, "encoding", relativeFile);
+    if (!"nested_lists".equals(encoding)) {
+      throw new SourceException(
+          "data.transitions.encoding must be 'nested_lists' in '" + relativeFile + "'.");
+    }
+    ArrayNode values = requireArray(transitions, "values", relativeFile);
+    validateTransitionValues(values, bucketCount, nStates, relativeFile);
+
+    JsonNode gmms = requireObject(data, "gmms", relativeFile);
+    ArrayNode buckets = requireArray(gmms, "buckets", relativeFile);
+    if (buckets.size() != bucketCount) {
+      throw new SourceException(
+          "data.gmms.buckets must contain " + bucketCount + " elements in '" + relativeFile + "'.");
+    }
+    validateGmms(buckets, nStates, relativeFile);
+
+    return new JsonMetadata(nStates, bucketCount, seriesId);
+  }
+
+  private void validateTransitionValues(
+      ArrayNode values, int bucketCount, int nStates, Path relativeFile) throws SourceException {
+    if (values.size() != bucketCount) {
+      throw new SourceException(
+          "data.transitions.values must contain "
+              + bucketCount
+              + " buckets in '"
+              + relativeFile
+              + "'.");
+    }
+    for (int bucketIndex = 0; bucketIndex < values.size(); bucketIndex++) {
+      JsonNode bucketNode = values.get(bucketIndex);
+      if (!bucketNode.isArray()) {
+        throw new SourceException(
+            "Bucket "
+                + bucketIndex
+                + " in data.transitions.values of '"
+                + relativeFile
+                + "' is not an array.");
+      }
+      ArrayNode bucket = (ArrayNode) bucketNode;
+      if (bucket.size() != nStates) {
+        throw new SourceException(
+            "Bucket "
+                + bucketIndex
+                + " in data.transitions.values must contain "
+                + nStates
+                + " rows in '"
+                + relativeFile
+                + "'.");
+      }
+      for (int rowIndex = 0; rowIndex < bucket.size(); rowIndex++) {
+        JsonNode rowNode = bucket.get(rowIndex);
+        if (!rowNode.isArray()) {
+          throw new SourceException(
+              "Row "
+                  + rowIndex
+                  + " in bucket "
+                  + bucketIndex
+                  + " of data.transitions.values in '"
+                  + relativeFile
+                  + "' is not an array.");
+        }
+        ArrayNode row = (ArrayNode) rowNode;
+        if (row.size() != nStates) {
+          throw new SourceException(
+              "Row "
+                  + rowIndex
+                  + " in bucket "
+                  + bucketIndex
+                  + " must contain "
+                  + nStates
+                  + " values in '"
+                  + relativeFile
+                  + "'.");
+        }
+        for (int colIndex = 0; colIndex < row.size(); colIndex++) {
+          if (!row.get(colIndex).isNumber()) {
+            throw new SourceException(
+                "Non-numeric entry found in data.transitions.values at bucket "
+                    + bucketIndex
+                    + ", row "
+                    + rowIndex
+                    + ", column "
+                    + colIndex
+                    + " in '"
+                    + relativeFile
+                    + "'.");
+          }
+        }
+      }
+    }
+  }
+
+  private void validateGmms(ArrayNode buckets, int nStates, Path relativeFile)
+      throws SourceException {
+    for (int bucketIndex = 0; bucketIndex < buckets.size(); bucketIndex++) {
+      JsonNode bucketNode = buckets.get(bucketIndex);
+      if (!bucketNode.isObject()) {
+        throw new SourceException(
+            "Bucket "
+                + bucketIndex
+                + " in data.gmms.buckets of '"
+                + relativeFile
+                + "' is not an object.");
+      }
+      JsonNode statesNode = requireArray(bucketNode, "states", relativeFile);
+      if (statesNode.size() != nStates) {
+        throw new SourceException(
+            "Bucket "
+                + bucketIndex
+                + " in data.gmms.buckets must contain "
+                + nStates
+                + " state entries in '"
+                + relativeFile
+                + "'.");
+      }
+      for (int stateIndex = 0; stateIndex < statesNode.size(); stateIndex++) {
+        JsonNode stateNode = statesNode.get(stateIndex);
+        if (stateNode.isNull()) {
+          continue;
+        }
+        if (!stateNode.isObject()) {
+          throw new SourceException(
+              "State "
+                  + stateIndex
+                  + " in bucket "
+                  + bucketIndex
+                  + " of data.gmms.buckets in '"
+                  + relativeFile
+                  + "' is not an object.");
+        }
+        ArrayNode weights = requireArray(stateNode, "weights", relativeFile);
+        ArrayNode means = requireArray(stateNode, "means", relativeFile);
+        ArrayNode variances = requireArray(stateNode, "variances", relativeFile);
+
+        int mixtureSize = weights.size();
+        if (means.size() != mixtureSize || variances.size() != mixtureSize) {
+          throw new SourceException(
+              "Gaussian mixture of state "
+                  + stateIndex
+                  + " in bucket "
+                  + bucketIndex
+                  + " must have equal number of weights, means, and variances in '"
+                  + relativeFile
+                  + "'.");
+        }
+        for (int componentIndex = 0; componentIndex < mixtureSize; componentIndex++) {
+          if (!weights.get(componentIndex).isNumber()) {
+            throw new SourceException(
+                "Non-numeric weight found in Gaussian mixture of state "
+                    + stateIndex
+                    + ", bucket "
+                    + bucketIndex
+                    + " in '"
+                    + relativeFile
+                    + "'.");
+          }
+          if (!means.get(componentIndex).isNumber()) {
+            throw new SourceException(
+                "Non-numeric mean found in Gaussian mixture of state "
+                    + stateIndex
+                    + ", bucket "
+                    + bucketIndex
+                    + " in '"
+                    + relativeFile
+                    + "'.");
+          }
+          if (!variances.get(componentIndex).isNumber()) {
+            throw new SourceException(
+                "Non-numeric variance found in Gaussian mixture of state "
+                    + stateIndex
+                    + ", bucket "
+                    + bucketIndex
+                    + " in '"
+                    + relativeFile
+                    + "'.");
+          }
+          double variance = variances.get(componentIndex).asDouble();
+          if (variance < 0d) {
+            throw new SourceException(
+                "Negative variance "
+                    + variance
+                    + " in Gaussian mixture of state "
+                    + stateIndex
+                    + ", bucket "
+                    + bucketIndex
+                    + " in '"
+                    + relativeFile
+                    + "'.");
+          }
+        }
+      }
+    }
+  }
+
+  private JsonNode requireObject(JsonNode parent, String field, Path relativeFile)
+      throws SourceException {
+    JsonNode node = requireNode(parent, field, relativeFile);
+    if (!node.isObject()) {
+      throw new SourceException(
+          "Field '" + field + "' in '" + relativeFile + "' must be an object.");
+    }
+    return node;
+  }
+
+  private ArrayNode requireArray(JsonNode parent, String field, Path relativeFile)
+      throws SourceException {
+    JsonNode node = requireNode(parent, field, relativeFile);
+    if (!node.isArray()) {
+      throw new SourceException(
+          "Field '" + field + "' in '" + relativeFile + "' must be an array.");
+    }
+    return (ArrayNode) node;
+  }
+
+  private JsonNode requireNode(JsonNode parent, String field, Path relativeFile)
+      throws SourceException {
+    if (!parent.has(field)) {
+      throw new SourceException("Missing field '" + field + "' in '" + relativeFile + "'.");
+    }
+    return parent.get(field);
+  }
+
+  private String requireText(JsonNode parent, String field, Path relativeFile)
+      throws SourceException {
+    JsonNode node = requireNode(parent, field, relativeFile);
+    if (!node.isTextual()) {
+      throw new SourceException("Field '" + field + "' in '" + relativeFile + "' must be textual.");
+    }
+    return node.asText();
+  }
+
+  private boolean requireBoolean(JsonNode parent, String field, Path relativeFile)
+      throws SourceException {
+    JsonNode node = requireNode(parent, field, relativeFile);
+    if (!node.isBoolean()) {
+      throw new SourceException("Field '" + field + "' in '" + relativeFile + "' must be boolean.");
+    }
+    return node.asBoolean();
+  }
+
+  private double requireDouble(JsonNode parent, String field, Path relativeFile)
+      throws SourceException {
+    JsonNode node = requireNode(parent, field, relativeFile);
+    if (!node.isNumber()) {
+      throw new SourceException("Field '" + field + "' in '" + relativeFile + "' must be numeric.");
+    }
+    return node.asDouble();
+  }
+
+  private int requirePositiveInt(JsonNode parent, String field, Path relativeFile)
+      throws SourceException {
+    JsonNode node = requireNode(parent, field, relativeFile);
+    if (!node.isInt()) {
+      throw new SourceException(
+          "Field '" + field + "' in '" + relativeFile + "' must be an integer.");
+    }
+    int value = node.asInt();
+    if (value <= 0) {
+      throw new SourceException(
+          "Field '"
+              + field
+              + "' in '"
+              + relativeFile
+              + "' must be positive but was "
+              + value
+              + ".");
+    }
+    return value;
+  }
+
+  private int requirePositiveInt(ArrayNode array, int index, Path relativeFile, String field)
+      throws SourceException {
+    if (index < 0 || index >= array.size()) {
+      throw new SourceException(
+          "Index " + index + " out of bounds for '" + field + "' in '" + relativeFile + "'.");
+    }
+    JsonNode node = array.get(index);
+    if (!node.isInt()) {
+      throw new SourceException(
+          "Entry " + index + " of '" + field + "' in '" + relativeFile + "' must be an integer.");
+    }
+    int value = node.asInt();
+    if (value <= 0) {
+      throw new SourceException(
+          "Entry "
+              + index
+              + " of '"
+              + field
+              + "' in '"
+              + relativeFile
+              + "' must be positive but was "
+              + value
+              + ".");
+    }
+    return value;
+  }
+
+  private record JsonMetadata(int nStates, int bucketCount, String seriesId) {}
+}

--- a/src/main/java/edu/ie3/datamodel/io/file/json/JsonTimeSeriesMetaInformationParser.java
+++ b/src/main/java/edu/ie3/datamodel/io/file/json/JsonTimeSeriesMetaInformationParser.java
@@ -28,12 +28,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class JsonTimeSeriesMetaInformationParser implements TimeSeriesMetaInformationParser {
 
   private static final String SUPPORTED_SCHEMA = "simonaMarkovLoad:psdm:1.0";
+  private static final String DATA_TRANSITIONS_SHAPE = "data.transitions.shape";
 
   private final Path basePath;
   private final FileNamingStrategy fileNamingStrategy;
@@ -116,7 +116,7 @@ public class JsonTimeSeriesMetaInformationParser implements TimeSeriesMetaInform
                   pattern
                       .matcher(FileNamingStrategy.removeFileNameEnding(relative.toString()))
                       .matches())
-          .collect(Collectors.toList());
+          .toList();
     } catch (IOException e) {
       throw new SourceException("Unable to inspect directory '" + basePath + "'.", e);
     }
@@ -165,15 +165,15 @@ public class JsonTimeSeriesMetaInformationParser implements TimeSeriesMetaInform
     int bucketCount = requirePositiveInt(timeModel, "bucket_count", relativeFile);
     JsonNode bucketEncoding = requireObject(timeModel, "bucket_encoding", relativeFile);
     requireText(bucketEncoding, "formula", relativeFile);
-    int samplingInterval = requirePositiveInt(timeModel, "sampling_interval_minutes", relativeFile);
-    String timezone = requireText(timeModel, "timezone", relativeFile);
+    requirePositiveInt(timeModel, "sampling_interval_minutes", relativeFile);
+    requireText(timeModel, "timezone", relativeFile);
 
     JsonNode valueModel = requireObject(root, "value_model", relativeFile);
-    String valueUnit = requireText(valueModel, "value_unit", relativeFile);
+    requireText(valueModel, "value_unit", relativeFile);
     JsonNode normalization = requireObject(valueModel, "normalization", relativeFile);
     requireText(normalization, "method", relativeFile);
     JsonNode discretization = requireObject(valueModel, "discretization", relativeFile);
-    int discretizationStates = requirePositiveInt(discretization, "states", relativeFile);
+    requirePositiveInt(discretization, "states", relativeFile);
     ArrayNode thresholdsRight = requireArray(discretization, "thresholds_right", relativeFile);
     if (thresholdsRight.isEmpty()) {
       throw new SourceException(
@@ -200,15 +200,19 @@ public class JsonTimeSeriesMetaInformationParser implements TimeSeriesMetaInform
     ArrayNode shape = requireArray(transitions, "shape", relativeFile);
     if (shape.size() != 3) {
       throw new SourceException(
-          "data.transitions.shape must contain exactly three elements in '" + relativeFile + "'.");
+          DATA_TRANSITIONS_SHAPE
+              + " must contain exactly three elements in '"
+              + relativeFile
+              + "'.");
     }
-    int shapeBuckets = requirePositiveInt(shape, 0, relativeFile, "data.transitions.shape");
-    int shapeStatesRows = requirePositiveInt(shape, 1, relativeFile, "data.transitions.shape");
-    int shapeStatesCols = requirePositiveInt(shape, 2, relativeFile, "data.transitions.shape");
+    int shapeBuckets = requirePositiveInt(shape, 0, relativeFile, DATA_TRANSITIONS_SHAPE);
+    int shapeStatesRows = requirePositiveInt(shape, 1, relativeFile, DATA_TRANSITIONS_SHAPE);
+    int shapeStatesCols = requirePositiveInt(shape, 2, relativeFile, DATA_TRANSITIONS_SHAPE);
 
     if (shapeBuckets != bucketCount || shapeStatesRows != nStates || shapeStatesCols != nStates) {
       throw new SourceException(
-          "data.transitions.shape "
+          DATA_TRANSITIONS_SHAPE
+              + " "
               + shape
               + " does not match bucket_count or n_states in '"
               + relativeFile

--- a/src/main/java/edu/ie3/datamodel/io/file/json/JsonTimeSeriesMetaInformationParser.java
+++ b/src/main/java/edu/ie3/datamodel/io/file/json/JsonTimeSeriesMetaInformationParser.java
@@ -67,7 +67,7 @@ public class JsonTimeSeriesMetaInformationParser implements TimeSeriesMetaInform
       LoadProfileMetaInformation namingMeta =
           fileNamingStrategy.loadProfileTimeSeriesMetaInformation(relativeFile.toString());
 
-      if (!metadata.seriesId().equals(namingMeta.getProfile())) {
+      if (metadata.seriesId() != null && !metadata.seriesId().equals(namingMeta.getProfile())) {
         throw new SourceException(
             "Series id '"
                 + metadata.seriesId()
@@ -144,6 +144,12 @@ public class JsonTimeSeriesMetaInformationParser implements TimeSeriesMetaInform
               + "'.");
     }
 
+    JsonNode generatedAt = root.get("generated_at");
+    if (generatedAt != null && !generatedAt.isTextual()) {
+      throw new SourceException(
+          "Field 'generated_at' in '" + relativeFile + "' must be textual if provided.");
+    }
+
     JsonNode generator = requireObject(root, "generator", relativeFile);
     requireText(generator, "name", relativeFile);
     requireText(generator, "version", relativeFile);
@@ -175,85 +181,19 @@ public class JsonTimeSeriesMetaInformationParser implements TimeSeriesMetaInform
               + relativeFile
               + "'.");
     }
-    thresholdsRight.forEach(
-        node -> {
-          if (!node.isNumber()) {
-            throw new IllegalStateException(
-                "Non-numeric entry in thresholds_right of '" + relativeFile + "'.");
-          }
-        });
+    for (JsonNode threshold : thresholdsRight) {
+      if (!threshold.isNumber()) {
+        throw new SourceException(
+            "Non-numeric entry in value_model.discretization.thresholds_right of '"
+                + relativeFile
+                + "'.");
+      }
+    }
 
     JsonNode parameters = requireObject(root, "parameters", relativeFile);
     JsonNode transitionsParam = requireObject(parameters, "transitions", relativeFile);
     requireText(transitionsParam, "empty_row_strategy", relativeFile);
     requireObject(parameters, "gmm", relativeFile);
-
-    JsonNode series = requireObject(root, "series", relativeFile);
-    String seriesId = requireText(series, "id", relativeFile);
-    requireText(series, "display_name", relativeFile);
-    String seriesUnit = requireText(series, "unit", relativeFile);
-    String seriesTimezone = requireText(series, "timezone", relativeFile);
-    int seriesSampling = requirePositiveInt(series, "sampling_interval_minutes", relativeFile);
-    int seriesStates = requirePositiveInt(series, "n_states", relativeFile);
-    JsonNode dataRef = requireObject(series, "data_ref", relativeFile);
-    requireText(dataRef, "type", relativeFile);
-    boolean transitionsInline = requireBoolean(dataRef, "transitions", relativeFile);
-    boolean gmmsInline = requireBoolean(dataRef, "gmms", relativeFile);
-
-    if (!seriesUnit.equals(valueUnit)) {
-      throw new SourceException(
-          "series.unit '"
-              + seriesUnit
-              + "' does not match value_model.value_unit '"
-              + valueUnit
-              + "' in '"
-              + relativeFile
-              + "'.");
-    }
-    if (!seriesTimezone.equals(timezone)) {
-      throw new SourceException(
-          "series.timezone '"
-              + seriesTimezone
-              + "' does not match time_model.timezone '"
-              + timezone
-              + "' in '"
-              + relativeFile
-              + "'.");
-    }
-    if (seriesSampling != samplingInterval) {
-      throw new SourceException(
-          "series.sampling_interval_minutes "
-              + seriesSampling
-              + " does not match time_model.sampling_interval_minutes "
-              + samplingInterval
-              + " in '"
-              + relativeFile
-              + "'.");
-    }
-    if (seriesStates != nStates) {
-      throw new SourceException(
-          "series.n_states "
-              + seriesStates
-              + " does not match generator.config.n_states "
-              + nStates
-              + " in '"
-              + relativeFile
-              + "'.");
-    }
-    if (discretizationStates != nStates) {
-      throw new SourceException(
-          "value_model.discretization.states "
-              + discretizationStates
-              + " does not match generator.config.n_states "
-              + nStates
-              + " in '"
-              + relativeFile
-              + "'.");
-    }
-    if (!transitionsInline || !gmmsInline) {
-      throw new SourceException(
-          "data_ref for '" + relativeFile + "' must declare transitions and gmms as inline.");
-    }
 
     JsonNode data = requireObject(root, "data", relativeFile);
     JsonNode transitions = requireObject(data, "transitions", relativeFile);
@@ -296,7 +236,7 @@ public class JsonTimeSeriesMetaInformationParser implements TimeSeriesMetaInform
     }
     validateGmms(buckets, nStates, relativeFile);
 
-    return new JsonMetadata(nStates, bucketCount, seriesId);
+    return new JsonMetadata(nStates, bucketCount, null);
   }
 
   private void validateTransitionValues(

--- a/src/main/java/edu/ie3/datamodel/io/source/LoadProfileSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/LoadProfileSource.java
@@ -9,11 +9,11 @@ import static edu.ie3.datamodel.models.profile.LoadProfile.RandomLoadProfile.RAN
 
 import edu.ie3.datamodel.exceptions.FactoryException;
 import edu.ie3.datamodel.exceptions.SourceException;
-import edu.ie3.datamodel.io.csv.CsvLoadProfileMetaInformation;
 import edu.ie3.datamodel.io.factory.timeseries.BdewLoadProfileFactory;
 import edu.ie3.datamodel.io.factory.timeseries.LoadProfileData;
 import edu.ie3.datamodel.io.factory.timeseries.LoadProfileFactory;
 import edu.ie3.datamodel.io.factory.timeseries.RandomLoadProfileFactory;
+import edu.ie3.datamodel.io.file.FileLoadProfileMetaInformation;
 import edu.ie3.datamodel.io.source.csv.CsvDataSource;
 import edu.ie3.datamodel.io.source.csv.CsvLoadProfileSource;
 import edu.ie3.datamodel.models.profile.BdewStandardLoadProfile;
@@ -118,7 +118,7 @@ public abstract class LoadProfileSource<P extends LoadProfile, V extends LoadVal
     BdewLoadProfileFactory factory = new BdewLoadProfileFactory();
 
     return buildInSource
-        .getCsvLoadProfileMetaInformation(BdewStandardLoadProfile.values())
+        .getLoadProfileMetaInformation(BdewStandardLoadProfile.values())
         .values()
         .stream()
         .map(
@@ -137,8 +137,8 @@ public abstract class LoadProfileSource<P extends LoadProfile, V extends LoadVal
       getRandomLoadProfile() throws SourceException {
     CsvDataSource buildInSource = getBuildInSource(LoadProfileSource.class, "/load");
 
-    CsvLoadProfileMetaInformation metaInformation =
-        buildInSource.getCsvLoadProfileMetaInformation(RANDOM_LOAD_PROFILE).values().stream()
+    FileLoadProfileMetaInformation metaInformation =
+        buildInSource.getLoadProfileMetaInformation(RANDOM_LOAD_PROFILE).values().stream()
             .findAny()
             .orElseThrow();
     return new CsvLoadProfileSource<>(

--- a/src/main/java/edu/ie3/datamodel/io/source/csv/CsvDataSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/csv/CsvDataSource.java
@@ -8,7 +8,8 @@ package edu.ie3.datamodel.io.source.csv;
 import edu.ie3.datamodel.exceptions.SourceException;
 import edu.ie3.datamodel.io.connectors.CsvFileConnector;
 import edu.ie3.datamodel.io.csv.CsvIndividualTimeSeriesMetaInformation;
-import edu.ie3.datamodel.io.csv.CsvLoadProfileMetaInformation;
+import edu.ie3.datamodel.io.file.FileLoadProfileMetaInformation;
+import edu.ie3.datamodel.io.file.FileType;
 import edu.ie3.datamodel.io.naming.FileNamingStrategy;
 import edu.ie3.datamodel.io.naming.TimeSeriesMetaInformation;
 import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme;
@@ -158,17 +159,18 @@ public class CsvDataSource implements DataSource {
    *
    * @return A mapping from profile to the load profile time series meta information
    */
-  public Map<String, CsvLoadProfileMetaInformation> getCsvLoadProfileMetaInformation(
+  public Map<String, FileLoadProfileMetaInformation> getLoadProfileMetaInformation(
       LoadProfile... profiles) {
     return getTimeSeriesFilePaths(fileNamingStrategy.getLoadProfileTimeSeriesPattern())
         .parallelStream()
         .map(
             filePath -> {
-              /* Extract meta information from file path and enhance it with the file path itself */
               LoadProfileMetaInformation metaInformation =
                   fileNamingStrategy.loadProfileTimeSeriesMetaInformation(filePath.toString());
-              return new CsvLoadProfileMetaInformation(
-                  metaInformation, FileNamingStrategy.removeFileNameEnding(filePath.getFileName()));
+              Path fileNameWithoutEnding =
+                  FileNamingStrategy.removeFileNameEnding(filePath.getFileName());
+              return new FileLoadProfileMetaInformation(
+                  metaInformation, fileNameWithoutEnding, FileType.CSV);
             })
         .filter(
             metaInformation ->
@@ -177,6 +179,11 @@ public class CsvDataSource implements DataSource {
                     || Stream.of(profiles)
                         .anyMatch(profile -> profile.getKey().equals(metaInformation.getProfile())))
         .collect(Collectors.toMap(LoadProfileMetaInformation::getProfile, Function.identity()));
+  }
+
+  public Map<String, FileLoadProfileMetaInformation> getCsvLoadProfileMetaInformation(
+      LoadProfile... profiles) {
+    return getLoadProfileMetaInformation(profiles);
   }
 
   /**

--- a/src/main/java/edu/ie3/datamodel/io/source/csv/CsvLoadProfileSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/csv/CsvLoadProfileSource.java
@@ -8,8 +8,8 @@ package edu.ie3.datamodel.io.source.csv;
 import edu.ie3.datamodel.exceptions.FactoryException;
 import edu.ie3.datamodel.exceptions.SourceException;
 import edu.ie3.datamodel.exceptions.ValidationException;
-import edu.ie3.datamodel.io.csv.CsvLoadProfileMetaInformation;
 import edu.ie3.datamodel.io.factory.timeseries.LoadProfileFactory;
+import edu.ie3.datamodel.io.file.FileLoadProfileMetaInformation;
 import edu.ie3.datamodel.io.source.LoadProfileSource;
 import edu.ie3.datamodel.models.profile.LoadProfile;
 import edu.ie3.datamodel.models.timeseries.repetitive.LoadProfileEntry;
@@ -37,12 +37,12 @@ public class CsvLoadProfileSource<P extends LoadProfile, V extends LoadValues<P>
 
   public CsvLoadProfileSource(
       CsvDataSource source,
-      CsvLoadProfileMetaInformation metaInformation,
+      FileLoadProfileMetaInformation metaInformation,
       Class<V> entryClass,
       LoadProfileFactory<P, V> entryFactory) {
     super(entryClass, entryFactory);
     this.dataSource = source;
-    this.filePath = metaInformation.getFullFilePath();
+    this.filePath = metaInformation.getPath();
 
     /* Read in the full time series */
     try {
@@ -106,7 +106,7 @@ public class CsvLoadProfileSource<P extends LoadProfile, V extends LoadValues<P>
    * @return an individual time series
    */
   protected LoadProfileTimeSeries<P, V> buildLoadProfileTimeSeries(
-      CsvLoadProfileMetaInformation metaInformation,
+      FileLoadProfileMetaInformation metaInformation,
       Function<Map<String, String>, Try<LoadProfileEntry<V>, FactoryException>>
           fieldToValueFunction)
       throws SourceException {

--- a/src/main/java/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesMappingSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesMappingSource.java
@@ -1,11 +1,14 @@
 /*
- * © 2021. TU Dortmund University,
+ * © 2025. TU Dortmund University,
  * Institute of Energy Systems, Energy Efficiency and Energy Economics,
  * Research group Distribution grid planning and operation
 */
 package edu.ie3.datamodel.io.source.csv;
 
 import edu.ie3.datamodel.exceptions.SourceException;
+import edu.ie3.datamodel.io.file.FileTimeSeriesParserFactory;
+import edu.ie3.datamodel.io.file.FileType;
+import edu.ie3.datamodel.io.file.TimeSeriesMappingParser;
 import edu.ie3.datamodel.io.naming.FileNamingStrategy;
 import edu.ie3.datamodel.io.source.TimeSeriesMappingSource;
 import java.nio.file.Path;
@@ -16,20 +19,31 @@ import java.util.stream.Stream;
 
 public class CsvTimeSeriesMappingSource extends TimeSeriesMappingSource {
 
-  private final CsvDataSource dataSource;
+  private final TimeSeriesMappingParser parser;
 
   public CsvTimeSeriesMappingSource(
-      String csvSep, Path gridFolderPath, FileNamingStrategy fileNamingStrategy) {
-    this.dataSource = new CsvDataSource(csvSep, gridFolderPath, fileNamingStrategy);
+      Path path, FileType fileType, FileNamingStrategy fileNamingStrategy, String csvSeparator) {
+    this(path, fileType, fileNamingStrategy, csvSeparator, new FileTimeSeriesParserFactory());
+  }
+
+  CsvTimeSeriesMappingSource(
+      Path path,
+      FileType fileType,
+      FileNamingStrategy fileNamingStrategy,
+      String csvSeparator,
+      FileTimeSeriesParserFactory parserFactory) {
+    String effectiveSeparator = csvSeparator == null ? "," : csvSeparator;
+    this.parser =
+        parserFactory.mappingParser(path, fileType, fileNamingStrategy, effectiveSeparator);
   }
 
   @Override
   public Stream<Map<String, String>> getMappingSourceData() throws SourceException {
-    return dataSource.buildStreamWithFieldsToAttributesMap(MappingEntry.class, true).getOrThrow();
+    return parser.parse();
   }
 
   @Override
   public Optional<Set<String>> getSourceFields() throws SourceException {
-    return dataSource.getSourceFields(MappingEntry.class);
+    return parser.availableFields();
   }
 }

--- a/src/main/java/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesMetaInformationSource.java
+++ b/src/main/java/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesMetaInformationSource.java
@@ -1,11 +1,15 @@
 /*
- * © 2022. TU Dortmund University,
+ * © 2025. TU Dortmund University,
  * Institute of Energy Systems, Energy Efficiency and Energy Economics,
  * Research group Distribution grid planning and operation
 */
 package edu.ie3.datamodel.io.source.csv;
 
-import edu.ie3.datamodel.io.csv.CsvIndividualTimeSeriesMetaInformation;
+import edu.ie3.datamodel.exceptions.SourceException;
+import edu.ie3.datamodel.io.file.FileLoadProfileMetaInformation;
+import edu.ie3.datamodel.io.file.FileTimeSeriesParserFactory;
+import edu.ie3.datamodel.io.file.FileType;
+import edu.ie3.datamodel.io.file.TimeSeriesMetaInformationParser;
 import edu.ie3.datamodel.io.naming.FileNamingStrategy;
 import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme;
 import edu.ie3.datamodel.io.naming.timeseries.IndividualTimeSeriesMetaInformation;
@@ -17,51 +21,52 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
-/**
- * CSV implementation for retrieving {@link TimeSeriesMetaInformationSource} from input directory
- * structures
- */
 public class CsvTimeSeriesMetaInformationSource extends TimeSeriesMetaInformationSource {
 
-  protected final CsvDataSource dataSource;
+  private final Map<UUID, IndividualTimeSeriesMetaInformation> timeSeriesMetaInformation;
 
-  private final Map<UUID, CsvIndividualTimeSeriesMetaInformation> timeSeriesMetaInformation;
-
-  /**
-   * Creates a time series type source
-   *
-   * @param csvSep the CSV separator
-   * @param folderPath path that time series reside in
-   * @param fileNamingStrategy the file naming strategy
-   */
   public CsvTimeSeriesMetaInformationSource(
-      String csvSep, Path folderPath, FileNamingStrategy fileNamingStrategy) {
-    this(new CsvDataSource(csvSep, folderPath, fileNamingStrategy));
+      Path path, FileType fileType, FileNamingStrategy fileNamingStrategy, String csvSeparator) {
+    this(path, fileType, fileNamingStrategy, csvSeparator, new FileTimeSeriesParserFactory());
   }
 
-  /**
-   * Creates a time series type source
-   *
-   * @param dataSource a csv data source
-   */
-  public CsvTimeSeriesMetaInformationSource(CsvDataSource dataSource) {
-    this.dataSource = dataSource;
-    // retrieve only the desired time series
-    this.timeSeriesMetaInformation =
-        dataSource.getCsvIndividualTimeSeriesMetaInformation(
-            TimeSeriesUtils.getAcceptedColumnSchemes().toArray(new ColumnScheme[0]));
+  CsvTimeSeriesMetaInformationSource(
+      Path path,
+      FileType fileType,
+      FileNamingStrategy fileNamingStrategy,
+      String csvSeparator,
+      FileTimeSeriesParserFactory parserFactory) {
+    String effectiveSeparator = csvSeparator == null ? "," : csvSeparator;
+    TimeSeriesMetaInformationParser parser =
+        parserFactory.metaInformationParser(path, fileType, fileNamingStrategy, effectiveSeparator);
 
-    this.loadProfileMetaInformation =
-        dataSource.getCsvLoadProfileMetaInformation().values().stream()
-            .collect(Collectors.toMap(LoadProfileMetaInformation::getProfile, Function.identity()));
+    try {
+      ColumnScheme[] acceptedSchemes =
+          TimeSeriesUtils.getAcceptedColumnSchemes().toArray(new ColumnScheme[0]);
+      this.timeSeriesMetaInformation =
+          Collections.unmodifiableMap(
+              parser.parseIndividualTimeSeriesMetaInformation(acceptedSchemes));
+
+      Map<String, FileLoadProfileMetaInformation> parsedLoadProfiles =
+          parser.parseLoadProfileMetaInformation();
+      this.loadProfileMetaInformation =
+          Collections.unmodifiableMap(
+              parsedLoadProfiles.entrySet().stream()
+                  .collect(
+                      Collectors.toMap(
+                          Map.Entry::getKey,
+                          entry -> (LoadProfileMetaInformation) entry.getValue())));
+    } catch (SourceException e) {
+      throw new IllegalStateException(
+          "Unable to initialize time series meta information source for " + fileType + '.', e);
+    }
   }
 
   @Override
   public Map<UUID, IndividualTimeSeriesMetaInformation> getTimeSeriesMetaInformation() {
-    return Collections.unmodifiableMap(timeSeriesMetaInformation);
+    return timeSeriesMetaInformation;
   }
 
   @Override

--- a/src/main/java/edu/ie3/datamodel/models/input/system/BmInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/BmInput.java
@@ -117,6 +117,11 @@ public class BmInput extends SystemParticipantInput implements HasType {
     return feedInTariff;
   }
 
+  @Override
+  public ComparableQuantity<Power> getsRated() {
+    return this.type.getsRated();
+  }
+
   public BmInputCopyBuilder copy() {
     return new BmInputCopyBuilder(this);
   }

--- a/src/main/java/edu/ie3/datamodel/models/input/system/BmInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/BmInput.java
@@ -119,7 +119,7 @@ public class BmInput extends SystemParticipantInput implements HasType {
   }
 
   @Override
-  public ComparableQuantity<Power> getsRated() {
+  public ComparableQuantity<Power> sRated() {
     return this.type.getsRated();
   }
 

--- a/src/main/java/edu/ie3/datamodel/models/input/system/BmInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/BmInput.java
@@ -16,6 +16,7 @@ import edu.ie3.datamodel.models.input.system.type.BmTypeInput;
 import edu.ie3.util.quantities.interfaces.EnergyPrice;
 import java.util.Objects;
 import java.util.UUID;
+import javax.measure.quantity.Power;
 import tech.units.indriya.ComparableQuantity;
 
 /** Describes a biomass plant */

--- a/src/main/java/edu/ie3/datamodel/models/input/system/ChpInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/ChpInput.java
@@ -17,6 +17,7 @@ import edu.ie3.datamodel.models.input.system.type.ChpTypeInput;
 import edu.ie3.datamodel.models.input.thermal.ThermalBusInput;
 import edu.ie3.datamodel.models.input.thermal.ThermalStorageInput;
 import java.util.Objects;
+import javax.measure.quantity.Power;
 import java.util.UUID;
 
 /** Describes a combined heat and power plant */

--- a/src/main/java/edu/ie3/datamodel/models/input/system/ChpInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/ChpInput.java
@@ -17,9 +17,9 @@ import edu.ie3.datamodel.models.input.system.type.ChpTypeInput;
 import edu.ie3.datamodel.models.input.thermal.ThermalBusInput;
 import edu.ie3.datamodel.models.input.thermal.ThermalStorageInput;
 import java.util.Objects;
+import java.util.UUID;
 import javax.measure.quantity.Power;
 import tech.units.indriya.ComparableQuantity;
-import java.util.UUID;
 
 /** Describes a combined heat and power plant */
 public class ChpInput extends SystemParticipantInput

--- a/src/main/java/edu/ie3/datamodel/models/input/system/ChpInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/ChpInput.java
@@ -122,7 +122,7 @@ public class ChpInput extends SystemParticipantInput
   }
 
   @Override
-  public ComparableQuantity<Power> getsRated() {
+  public ComparableQuantity<Power> sRated() {
     return this.type.getsRated();
   }
 

--- a/src/main/java/edu/ie3/datamodel/models/input/system/ChpInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/ChpInput.java
@@ -18,6 +18,7 @@ import edu.ie3.datamodel.models.input.thermal.ThermalBusInput;
 import edu.ie3.datamodel.models.input.thermal.ThermalStorageInput;
 import java.util.Objects;
 import javax.measure.quantity.Power;
+import tech.units.indriya.ComparableQuantity;
 import java.util.UUID;
 
 /** Describes a combined heat and power plant */

--- a/src/main/java/edu/ie3/datamodel/models/input/system/ChpInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/ChpInput.java
@@ -119,6 +119,11 @@ public class ChpInput extends SystemParticipantInput
     return marketReaction;
   }
 
+  @Override
+  public ComparableQuantity<Power> getsRated() {
+    return this.type.getsRated();
+  }
+
   public ChpInputCopyBuilder copy() {
     return new ChpInputCopyBuilder(this);
   }

--- a/src/main/java/edu/ie3/datamodel/models/input/system/EvInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/EvInput.java
@@ -14,6 +14,7 @@ import edu.ie3.datamodel.models.input.system.characteristic.ReactivePowerCharact
 import edu.ie3.datamodel.models.input.system.type.EvTypeInput;
 import java.util.Objects;
 import javax.measure.quantity.Power;
+import tech.units.indriya.ComparableQuantity;
 import java.util.UUID;
 
 /** Describes an electric vehicle */

--- a/src/main/java/edu/ie3/datamodel/models/input/system/EvInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/EvInput.java
@@ -71,6 +71,11 @@ public class EvInput extends SystemParticipantInput implements HasType {
     return type;
   }
 
+  @Override
+  public ComparableQuantity<Power> getsRated() {
+    return this.type.getsRated();
+  }
+
   public EvInputCopyBuilder copy() {
     return new EvInputCopyBuilder(this);
   }

--- a/src/main/java/edu/ie3/datamodel/models/input/system/EvInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/EvInput.java
@@ -13,9 +13,9 @@ import edu.ie3.datamodel.models.input.OperatorInput;
 import edu.ie3.datamodel.models.input.system.characteristic.ReactivePowerCharacteristic;
 import edu.ie3.datamodel.models.input.system.type.EvTypeInput;
 import java.util.Objects;
+import java.util.UUID;
 import javax.measure.quantity.Power;
 import tech.units.indriya.ComparableQuantity;
-import java.util.UUID;
 
 /** Describes an electric vehicle */
 public class EvInput extends SystemParticipantInput implements HasType {

--- a/src/main/java/edu/ie3/datamodel/models/input/system/EvInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/EvInput.java
@@ -74,7 +74,7 @@ public class EvInput extends SystemParticipantInput implements HasType {
   }
 
   @Override
-  public ComparableQuantity<Power> getsRated() {
+  public ComparableQuantity<Power> sRated() {
     return this.type.getsRated();
   }
 

--- a/src/main/java/edu/ie3/datamodel/models/input/system/EvInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/EvInput.java
@@ -13,6 +13,7 @@ import edu.ie3.datamodel.models.input.OperatorInput;
 import edu.ie3.datamodel.models.input.system.characteristic.ReactivePowerCharacteristic;
 import edu.ie3.datamodel.models.input.system.type.EvTypeInput;
 import java.util.Objects;
+import javax.measure.quantity.Power;
 import java.util.UUID;
 
 /** Describes an electric vehicle */

--- a/src/main/java/edu/ie3/datamodel/models/input/system/EvcsInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/EvcsInput.java
@@ -13,6 +13,7 @@ import edu.ie3.datamodel.models.input.system.characteristic.ReactivePowerCharact
 import edu.ie3.datamodel.models.input.system.type.chargingpoint.ChargingPointType;
 import edu.ie3.datamodel.models.input.system.type.evcslocation.EvcsLocationType;
 import java.util.Objects;
+import javax.measure.quantity.Power;
 import java.util.UUID;
 
 public class EvcsInput extends SystemParticipantInput {

--- a/src/main/java/edu/ie3/datamodel/models/input/system/EvcsInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/EvcsInput.java
@@ -14,6 +14,7 @@ import edu.ie3.datamodel.models.input.system.type.chargingpoint.ChargingPointTyp
 import edu.ie3.datamodel.models.input.system.type.evcslocation.EvcsLocationType;
 import java.util.Objects;
 import javax.measure.quantity.Power;
+import tech.units.indriya.ComparableQuantity;
 import java.util.UUID;
 
 public class EvcsInput extends SystemParticipantInput {

--- a/src/main/java/edu/ie3/datamodel/models/input/system/EvcsInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/EvcsInput.java
@@ -185,7 +185,7 @@ public class EvcsInput extends SystemParticipantInput {
   }
 
   @Override
-  public ComparableQuantity<Power> getsRated() {
+  public ComparableQuantity<Power> sRated() {
     return this.type.getsRated();
   }
 

--- a/src/main/java/edu/ie3/datamodel/models/input/system/EvcsInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/EvcsInput.java
@@ -13,9 +13,9 @@ import edu.ie3.datamodel.models.input.system.characteristic.ReactivePowerCharact
 import edu.ie3.datamodel.models.input.system.type.chargingpoint.ChargingPointType;
 import edu.ie3.datamodel.models.input.system.type.evcslocation.EvcsLocationType;
 import java.util.Objects;
+import java.util.UUID;
 import javax.measure.quantity.Power;
 import tech.units.indriya.ComparableQuantity;
-import java.util.UUID;
 
 public class EvcsInput extends SystemParticipantInput {
 

--- a/src/main/java/edu/ie3/datamodel/models/input/system/EvcsInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/EvcsInput.java
@@ -183,6 +183,11 @@ public class EvcsInput extends SystemParticipantInput {
   }
 
   @Override
+  public ComparableQuantity<Power> getsRated() {
+    return this.type.getsRated();
+  }
+
+  @Override
   public EvcsInputCopyBuilder copy() {
     return new EvcsInputCopyBuilder(this);
   }

--- a/src/main/java/edu/ie3/datamodel/models/input/system/FixedFeedInInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/FixedFeedInInput.java
@@ -80,6 +80,11 @@ public class FixedFeedInInput extends SystemParticipantInput {
     return sRated;
   }
 
+  @Override
+  public ComparableQuantity<Power> sRated() {
+    return sRated;
+  }
+
   public double getCosPhiRated() {
     return cosPhiRated;
   }

--- a/src/main/java/edu/ie3/datamodel/models/input/system/HpInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/HpInput.java
@@ -90,7 +90,7 @@ public class HpInput extends SystemParticipantInput implements HasType, HasTherm
   }
 
   @Override
-  public ComparableQuantity<Power> getsRated() {
+  public ComparableQuantity<Power> sRated() {
     return this.type.getsRated();
   }
 

--- a/src/main/java/edu/ie3/datamodel/models/input/system/HpInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/HpInput.java
@@ -87,6 +87,11 @@ public class HpInput extends SystemParticipantInput implements HasType, HasTherm
     return thermalBus;
   }
 
+  @Override
+  public ComparableQuantity<Power> getsRated() {
+    return this.type.getsRated();
+  }
+
   public HpInputCopyBuilder copy() {
     return new HpInputCopyBuilder(this);
   }

--- a/src/main/java/edu/ie3/datamodel/models/input/system/HpInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/HpInput.java
@@ -15,6 +15,7 @@ import edu.ie3.datamodel.models.input.system.characteristic.ReactivePowerCharact
 import edu.ie3.datamodel.models.input.system.type.HpTypeInput;
 import edu.ie3.datamodel.models.input.thermal.ThermalBusInput;
 import java.util.Objects;
+import javax.measure.quantity.Power;
 import java.util.UUID;
 
 /** Describes a heat pump */

--- a/src/main/java/edu/ie3/datamodel/models/input/system/HpInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/HpInput.java
@@ -16,6 +16,8 @@ import edu.ie3.datamodel.models.input.system.type.HpTypeInput;
 import edu.ie3.datamodel.models.input.thermal.ThermalBusInput;
 import java.util.Objects;
 import javax.measure.quantity.Power;
+import tech.units.indriya.ComparableQuantity;
+import javax.measure.quantity.Power;
 import java.util.UUID;
 
 /** Describes a heat pump */

--- a/src/main/java/edu/ie3/datamodel/models/input/system/HpInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/HpInput.java
@@ -15,9 +15,9 @@ import edu.ie3.datamodel.models.input.system.characteristic.ReactivePowerCharact
 import edu.ie3.datamodel.models.input.system.type.HpTypeInput;
 import edu.ie3.datamodel.models.input.thermal.ThermalBusInput;
 import java.util.Objects;
+import java.util.UUID;
 import javax.measure.quantity.Power;
 import tech.units.indriya.ComparableQuantity;
-import java.util.UUID;
 
 /** Describes a heat pump */
 public class HpInput extends SystemParticipantInput implements HasType, HasThermalBus {

--- a/src/main/java/edu/ie3/datamodel/models/input/system/HpInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/HpInput.java
@@ -17,7 +17,6 @@ import edu.ie3.datamodel.models.input.thermal.ThermalBusInput;
 import java.util.Objects;
 import javax.measure.quantity.Power;
 import tech.units.indriya.ComparableQuantity;
-import javax.measure.quantity.Power;
 import java.util.UUID;
 
 /** Describes a heat pump */

--- a/src/main/java/edu/ie3/datamodel/models/input/system/LoadInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/LoadInput.java
@@ -199,6 +199,11 @@ public class LoadInput extends SystemParticipantInput {
     return sRated;
   }
 
+  @Override
+  public ComparableQuantity<Power> sRated() {
+    return sRated;
+  }
+
   public double getCosPhiRated() {
     return cosPhiRated;
   }

--- a/src/main/java/edu/ie3/datamodel/models/input/system/PvInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/PvInput.java
@@ -174,6 +174,7 @@ public class PvInput extends SystemParticipantInput {
     return kT;
   }
 
+  @Override
   public ComparableQuantity<Power> getsRated() {
     return sRated;
   }

--- a/src/main/java/edu/ie3/datamodel/models/input/system/PvInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/PvInput.java
@@ -17,7 +17,6 @@ import javax.measure.quantity.Angle;
 import javax.measure.quantity.Dimensionless;
 import javax.measure.quantity.Power;
 import tech.units.indriya.ComparableQuantity;
-import javax.measure.quantity.Power;
 
 /** Describes a photovoltaic plant */
 public class PvInput extends SystemParticipantInput {

--- a/src/main/java/edu/ie3/datamodel/models/input/system/PvInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/PvInput.java
@@ -174,8 +174,12 @@ public class PvInput extends SystemParticipantInput {
     return kT;
   }
 
-  @Override
   public ComparableQuantity<Power> getsRated() {
+    return sRated;
+  }
+
+  @Override
+  public ComparableQuantity<Power> sRated() {
     return sRated;
   }
 

--- a/src/main/java/edu/ie3/datamodel/models/input/system/PvInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/PvInput.java
@@ -17,6 +17,7 @@ import javax.measure.quantity.Angle;
 import javax.measure.quantity.Dimensionless;
 import javax.measure.quantity.Power;
 import tech.units.indriya.ComparableQuantity;
+import javax.measure.quantity.Power;
 
 /** Describes a photovoltaic plant */
 public class PvInput extends SystemParticipantInput {

--- a/src/main/java/edu/ie3/datamodel/models/input/system/StorageInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/StorageInput.java
@@ -13,9 +13,9 @@ import edu.ie3.datamodel.models.input.OperatorInput;
 import edu.ie3.datamodel.models.input.system.characteristic.ReactivePowerCharacteristic;
 import edu.ie3.datamodel.models.input.system.type.StorageTypeInput;
 import java.util.Objects;
+import java.util.UUID;
 import javax.measure.quantity.Power;
 import tech.units.indriya.ComparableQuantity;
-import java.util.UUID;
 
 /** Describes a battery storage */
 public class StorageInput extends SystemParticipantInput implements HasType {

--- a/src/main/java/edu/ie3/datamodel/models/input/system/StorageInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/StorageInput.java
@@ -71,6 +71,11 @@ public class StorageInput extends SystemParticipantInput implements HasType {
     return type;
   }
 
+  @Override
+  public ComparableQuantity<Power> getsRated() {
+    return this.type.getsRated();
+  }
+
   public StorageInputCopyBuilder copy() {
     return new StorageInputCopyBuilder(this);
   }

--- a/src/main/java/edu/ie3/datamodel/models/input/system/StorageInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/StorageInput.java
@@ -13,6 +13,7 @@ import edu.ie3.datamodel.models.input.OperatorInput;
 import edu.ie3.datamodel.models.input.system.characteristic.ReactivePowerCharacteristic;
 import edu.ie3.datamodel.models.input.system.type.StorageTypeInput;
 import java.util.Objects;
+import javax.measure.quantity.Power;
 import java.util.UUID;
 
 /** Describes a battery storage */

--- a/src/main/java/edu/ie3/datamodel/models/input/system/StorageInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/StorageInput.java
@@ -14,6 +14,7 @@ import edu.ie3.datamodel.models.input.system.characteristic.ReactivePowerCharact
 import edu.ie3.datamodel.models.input.system.type.StorageTypeInput;
 import java.util.Objects;
 import javax.measure.quantity.Power;
+import tech.units.indriya.ComparableQuantity;
 import java.util.UUID;
 
 /** Describes a battery storage */

--- a/src/main/java/edu/ie3/datamodel/models/input/system/StorageInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/StorageInput.java
@@ -74,7 +74,7 @@ public class StorageInput extends SystemParticipantInput implements HasType {
   }
 
   @Override
-  public ComparableQuantity<Power> getsRated() {
+  public ComparableQuantity<Power> sRated() {
     return this.type.getsRated();
   }
 

--- a/src/main/java/edu/ie3/datamodel/models/input/system/SystemParticipantInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/SystemParticipantInput.java
@@ -14,9 +14,9 @@ import edu.ie3.datamodel.models.input.EmInput;
 import edu.ie3.datamodel.models.input.NodeInput;
 import edu.ie3.datamodel.models.input.OperatorInput;
 import edu.ie3.datamodel.models.input.system.characteristic.ReactivePowerCharacteristic;
+import java.util.*;
 import javax.measure.quantity.Power;
 import tech.units.indriya.ComparableQuantity;
-import java.util.*;
 
 /** Describes a system asset that is connected to a node */
 public abstract class SystemParticipantInput extends AssetInput implements HasNodes, HasEm {

--- a/src/main/java/edu/ie3/datamodel/models/input/system/SystemParticipantInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/SystemParticipantInput.java
@@ -14,6 +14,7 @@ import edu.ie3.datamodel.models.input.EmInput;
 import edu.ie3.datamodel.models.input.NodeInput;
 import edu.ie3.datamodel.models.input.OperatorInput;
 import edu.ie3.datamodel.models.input.system.characteristic.ReactivePowerCharacteristic;
+import javax.measure.quantity.Power;
 import java.util.*;
 
 /** Describes a system asset that is connected to a node */

--- a/src/main/java/edu/ie3/datamodel/models/input/system/SystemParticipantInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/SystemParticipantInput.java
@@ -77,6 +77,8 @@ public abstract class SystemParticipantInput extends AssetInput implements HasNo
     this.controllingEm = em;
   }
 
+  public abstract ComparableQuantity<Power> getsRated();
+
   public NodeInput getNode() {
     return node;
   }

--- a/src/main/java/edu/ie3/datamodel/models/input/system/SystemParticipantInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/SystemParticipantInput.java
@@ -15,6 +15,7 @@ import edu.ie3.datamodel.models.input.NodeInput;
 import edu.ie3.datamodel.models.input.OperatorInput;
 import edu.ie3.datamodel.models.input.system.characteristic.ReactivePowerCharacteristic;
 import javax.measure.quantity.Power;
+import tech.units.indriya.ComparableQuantity;
 import java.util.*;
 
 /** Describes a system asset that is connected to a node */

--- a/src/main/java/edu/ie3/datamodel/models/input/system/SystemParticipantInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/SystemParticipantInput.java
@@ -79,7 +79,17 @@ public abstract class SystemParticipantInput extends AssetInput implements HasNo
     this.controllingEm = em;
   }
 
-  public abstract ComparableQuantity<Power> getsRated();
+  /**
+   * Returns the rated apparent power of the system participant, which is either stored within the
+   * {@link SystemParticipantInput} or linked {@link
+   * edu.ie3.datamodel.models.input.system.type.SystemParticipantTypeInput}.
+   *
+   * <p>Note: This cannot be a getter, because the accompanying field might not be present in
+   * subclasses.
+   *
+   * @return The rated apparent power.
+   */
+  public abstract ComparableQuantity<Power> sRated();
 
   public NodeInput getNode() {
     return node;

--- a/src/main/java/edu/ie3/datamodel/models/input/system/WecInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/WecInput.java
@@ -14,6 +14,7 @@ import edu.ie3.datamodel.models.input.system.characteristic.ReactivePowerCharact
 import edu.ie3.datamodel.models.input.system.type.WecTypeInput;
 import java.util.Objects;
 import javax.measure.quantity.Power;
+import tech.units.indriya.ComparableQuantity;
 import java.util.UUID;
 
 /** Describes a Wind Energy Converter */

--- a/src/main/java/edu/ie3/datamodel/models/input/system/WecInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/WecInput.java
@@ -85,6 +85,11 @@ public class WecInput extends SystemParticipantInput implements HasType {
     return type;
   }
 
+  @Override
+  public ComparableQuantity<Power> getsRated() {
+      return this.type.getsRated();
+  }
+
   public WecInputCopyBuilder copy() {
     return new WecInputCopyBuilder(this);
   }

--- a/src/main/java/edu/ie3/datamodel/models/input/system/WecInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/WecInput.java
@@ -88,7 +88,7 @@ public class WecInput extends SystemParticipantInput implements HasType {
   }
 
   @Override
-  public ComparableQuantity<Power> getsRated() {
+  public ComparableQuantity<Power> sRated() {
     return this.type.getsRated();
   }
 

--- a/src/main/java/edu/ie3/datamodel/models/input/system/WecInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/WecInput.java
@@ -13,9 +13,9 @@ import edu.ie3.datamodel.models.input.OperatorInput;
 import edu.ie3.datamodel.models.input.system.characteristic.ReactivePowerCharacteristic;
 import edu.ie3.datamodel.models.input.system.type.WecTypeInput;
 import java.util.Objects;
+import java.util.UUID;
 import javax.measure.quantity.Power;
 import tech.units.indriya.ComparableQuantity;
-import java.util.UUID;
 
 /** Describes a Wind Energy Converter */
 public class WecInput extends SystemParticipantInput implements HasType {
@@ -89,7 +89,7 @@ public class WecInput extends SystemParticipantInput implements HasType {
 
   @Override
   public ComparableQuantity<Power> getsRated() {
-      return this.type.getsRated();
+    return this.type.getsRated();
   }
 
   public WecInputCopyBuilder copy() {

--- a/src/main/java/edu/ie3/datamodel/models/input/system/WecInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/WecInput.java
@@ -13,6 +13,7 @@ import edu.ie3.datamodel.models.input.OperatorInput;
 import edu.ie3.datamodel.models.input.system.characteristic.ReactivePowerCharacteristic;
 import edu.ie3.datamodel.models.input.system.type.WecTypeInput;
 import java.util.Objects;
+import javax.measure.quantity.Power;
 import java.util.UUID;
 
 /** Describes a Wind Energy Converter */

--- a/src/test/groovy/edu/ie3/datamodel/io/connectors/CsvFileConnectorTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/connectors/CsvFileConnectorTest.groovy
@@ -76,6 +76,9 @@ class CsvFileConnectorTest extends Specification {
     noExceptionThrown()
     nodeFile.exists()
     nodeFile.file // is it a file?
+
+    cleanup:
+    connector.shutdown()
   }
 
   def "The csv file connector is able to init writers utilizing no directory hierarchy"() {
@@ -95,6 +98,9 @@ class CsvFileConnectorTest extends Specification {
     noExceptionThrown()
     nodeFile.exists()
     nodeFile.file // is it a file?
+
+    cleanup:
+    connector.shutdown()
   }
 
   def "Initialising a writer with incorrect base directory leads to ConnectorException"() {

--- a/src/test/groovy/edu/ie3/datamodel/io/source/csv/CsvDataSourceTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/source/csv/CsvDataSourceTest.groovy
@@ -8,7 +8,7 @@ package edu.ie3.datamodel.io.source.csv
 import edu.ie3.datamodel.exceptions.SourceException
 import edu.ie3.datamodel.io.connectors.CsvFileConnector
 import edu.ie3.datamodel.io.csv.CsvIndividualTimeSeriesMetaInformation
-import edu.ie3.datamodel.io.csv.CsvLoadProfileMetaInformation
+import edu.ie3.datamodel.io.file.FileLoadProfileMetaInformation
 import edu.ie3.datamodel.io.naming.FileNamingStrategy
 import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme
 import edu.ie3.datamodel.models.input.system.LoadInput
@@ -418,21 +418,21 @@ class CsvDataSourceTest extends Specification implements CsvTestDataMeta {
 
   def "The CsvDataSource is able to build correct load profile meta information"() {
     when:
-    def actual = dummyCsvSource.getCsvLoadProfileMetaInformation()
+    def actual = dummyCsvSource.getLoadProfileMetaInformation()
 
     then:
     actual.size() == 3
-    actual.get("r1").fullFilePath == Path.of("lpts_r1")
-    actual.get("r2").fullFilePath == Path.of("lpts_r2")
-    actual.get("g0").fullFilePath == Path.of("lpts_g0")
+    actual.get("r1").path == Path.of("lpts_r1")
+    actual.get("r2").path == Path.of("lpts_r2")
+    actual.get("g0").path == Path.of("lpts_g0")
   }
 
   def "The CsvDataSource is able to build correct load profile meta information when restricting load profile"() {
     when:
-    def actual = dummyCsvSource.getCsvLoadProfileMetaInformation(BdewStandardLoadProfile.G0)
+    def actual = dummyCsvSource.getLoadProfileMetaInformation(BdewStandardLoadProfile.G0)
 
     then:
     actual.size() == 1
-    actual.get("g0").fullFilePath == Path.of("lpts_g0")
+    actual.get("g0").path == Path.of("lpts_g0")
   }
 }

--- a/src/test/groovy/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesMappingSourceIT.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesMappingSourceIT.groovy
@@ -5,6 +5,7 @@
  */
 package edu.ie3.datamodel.io.source.csv
 
+import edu.ie3.datamodel.io.file.FileType
 import edu.ie3.datamodel.io.naming.FileNamingStrategy
 import edu.ie3.datamodel.io.source.TimeSeriesMappingSource
 import spock.lang.Shared
@@ -15,7 +16,7 @@ class CsvTimeSeriesMappingSourceIT extends Specification implements CsvTestDataM
   TimeSeriesMappingSource source
 
   def setupSpec() {
-    source = new CsvTimeSeriesMappingSource(";", timeSeriesFolderPath, new FileNamingStrategy())
+    source = new CsvTimeSeriesMappingSource(timeSeriesFolderPath, FileType.CSV, new FileNamingStrategy(), ";")
   }
 
   def "The csv time series mapping source is able to provide a valid time series mapping from files"() {

--- a/src/test/groovy/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesMetaInformationSourceIT.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/io/source/csv/CsvTimeSeriesMetaInformationSourceIT.groovy
@@ -6,6 +6,7 @@
 package edu.ie3.datamodel.io.source.csv
 
 import edu.ie3.datamodel.io.csv.CsvIndividualTimeSeriesMetaInformation
+import edu.ie3.datamodel.io.file.FileType
 import edu.ie3.datamodel.io.naming.FileNamingStrategy
 import edu.ie3.datamodel.io.naming.timeseries.ColumnScheme
 import spock.lang.Shared
@@ -18,7 +19,7 @@ class CsvTimeSeriesMetaInformationSourceIT extends Specification implements CsvT
   CsvTimeSeriesMetaInformationSource source
 
   def setupSpec() {
-    source = new CsvTimeSeriesMetaInformationSource(";", timeSeriesFolderPath, new FileNamingStrategy())
+    source = new CsvTimeSeriesMetaInformationSource(timeSeriesFolderPath, FileType.CSV, new FileNamingStrategy(), ";")
   }
 
   def "A CSV time series meta information source returns correct mapping of time series"() {

--- a/src/test/groovy/edu/ie3/datamodel/models/input/system/BmInputTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/input/system/BmInputTest.groovy
@@ -55,6 +55,7 @@ class BmInputTest extends Specification {
       assert qCharacteristics == bmInput.qCharacteristics
       assert feedInTariff == bmInput.feedInTariff
       assert type.sRated == bmInput.type.sRated * 2d
+      assert sRated == bmInput.type.sRated * 2d
       assert controllingEm == Optional.of(SystemParticipantTestData.emInput)
     }
   }

--- a/src/test/groovy/edu/ie3/datamodel/models/input/system/BmInputTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/input/system/BmInputTest.groovy
@@ -55,7 +55,7 @@ class BmInputTest extends Specification {
       assert qCharacteristics == bmInput.qCharacteristics
       assert feedInTariff == bmInput.feedInTariff
       assert type.sRated == bmInput.type.sRated * 2d
-      assert sRated == bmInput.type.sRated * 2d
+      assert sRated() == bmInput.type.sRated * 2d
       assert controllingEm == Optional.of(SystemParticipantTestData.emInput)
     }
   }

--- a/src/test/groovy/edu/ie3/datamodel/models/input/system/ChpInputTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/input/system/ChpInputTest.groovy
@@ -51,6 +51,7 @@ class ChpInputTest extends Specification {
       assert thermalStorage == chpInput.thermalStorage
       assert marketReaction == chpInput.marketReaction
       assert type.sRated == chpInput.type.sRated * 2d
+      assert sRated == chpInput.type.sRated * 2d
       assert type.pThermal == chpInput.type.pThermal * 2d
       assert type.pOwn == chpInput.type.pOwn * 2d
       assert controllingEm == Optional.of(SystemParticipantTestData.emInput)

--- a/src/test/groovy/edu/ie3/datamodel/models/input/system/ChpInputTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/input/system/ChpInputTest.groovy
@@ -51,7 +51,7 @@ class ChpInputTest extends Specification {
       assert thermalStorage == chpInput.thermalStorage
       assert marketReaction == chpInput.marketReaction
       assert type.sRated == chpInput.type.sRated * 2d
-      assert sRated == chpInput.type.sRated * 2d
+      assert sRated() == chpInput.type.sRated * 2d
       assert type.pThermal == chpInput.type.pThermal * 2d
       assert type.pOwn == chpInput.type.pOwn * 2d
       assert controllingEm == Optional.of(SystemParticipantTestData.emInput)

--- a/src/test/groovy/edu/ie3/datamodel/models/input/system/EvInputTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/input/system/EvInputTest.groovy
@@ -45,6 +45,7 @@ class EvInputTest extends Specification {
       assert id == ev.id
       assert qCharacteristics == ev.qCharacteristics
       assert type.sRated == ev.type.sRated * 2d
+      assert sRated == evcsInput.type.sRated * 2d
       assert type.sRatedDC == ev.type.sRatedDC * 2d
       assert type.eStorage == ev.type.eStorage * 2d
       assert type.eCons == ev.type.eCons * 2d

--- a/src/test/groovy/edu/ie3/datamodel/models/input/system/EvInputTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/input/system/EvInputTest.groovy
@@ -45,7 +45,7 @@ class EvInputTest extends Specification {
       assert id == ev.id
       assert qCharacteristics == ev.qCharacteristics
       assert type.sRated == ev.type.sRated * 2d
-      assert sRated == evcsInput.type.sRated * 2d
+      assert sRated == ev.type.sRated * 2d
       assert type.sRatedDC == ev.type.sRatedDC * 2d
       assert type.eStorage == ev.type.eStorage * 2d
       assert type.eCons == ev.type.eCons * 2d

--- a/src/test/groovy/edu/ie3/datamodel/models/input/system/EvInputTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/input/system/EvInputTest.groovy
@@ -45,7 +45,7 @@ class EvInputTest extends Specification {
       assert id == ev.id
       assert qCharacteristics == ev.qCharacteristics
       assert type.sRated == ev.type.sRated * 2d
-      assert sRated == ev.type.sRated * 2d
+      assert sRated() == ev.type.sRated * 2d
       assert type.sRatedDC == ev.type.sRatedDC * 2d
       assert type.eStorage == ev.type.eStorage * 2d
       assert type.eCons == ev.type.eCons * 2d

--- a/src/test/groovy/edu/ie3/datamodel/models/input/system/EvcsInputTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/input/system/EvcsInputTest.groovy
@@ -55,7 +55,7 @@ class EvcsInputTest extends Specification {
       assert id == evcsInput.id
       assert qCharacteristics == evcsInput.qCharacteristics
       assert type.sRated == evcsInput.type.sRated * 2d
-      assert sRated() == hpInput.type.sRated * 2d
+      assert sRated() == evcsInput.type.sRated * 2d
       assert cosPhiRated == evcsInput.cosPhiRated
       assert chargingPoints == evcsInput.chargingPoints
       assert locationType == evcsInput.locationType

--- a/src/test/groovy/edu/ie3/datamodel/models/input/system/EvcsInputTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/input/system/EvcsInputTest.groovy
@@ -55,6 +55,7 @@ class EvcsInputTest extends Specification {
       assert id == evcsInput.id
       assert qCharacteristics == evcsInput.qCharacteristics
       assert type.sRated == evcsInput.type.sRated * 2d
+      assert sRated == hpInput.type.sRated * 2d
       assert cosPhiRated == evcsInput.cosPhiRated
       assert chargingPoints == evcsInput.chargingPoints
       assert locationType == evcsInput.locationType

--- a/src/test/groovy/edu/ie3/datamodel/models/input/system/EvcsInputTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/input/system/EvcsInputTest.groovy
@@ -55,7 +55,7 @@ class EvcsInputTest extends Specification {
       assert id == evcsInput.id
       assert qCharacteristics == evcsInput.qCharacteristics
       assert type.sRated == evcsInput.type.sRated * 2d
-      assert sRated == hpInput.type.sRated * 2d
+      assert sRated() == hpInput.type.sRated * 2d
       assert cosPhiRated == evcsInput.cosPhiRated
       assert chargingPoints == evcsInput.chargingPoints
       assert locationType == evcsInput.locationType

--- a/src/test/groovy/edu/ie3/datamodel/models/input/system/HpInputTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/input/system/HpInputTest.groovy
@@ -48,6 +48,7 @@ class HpInputTest extends Specification {
       assert qCharacteristics == hpInput.qCharacteristics
       assert thermalBus == hpInput.thermalBus
       assert type.sRated == hpInput.type.sRated * 2d
+      assert sRated == hpInput.type.sRated * 2d
       assert type.pThermal == hpInput.type.pThermal * 2d
       assert controllingEm == Optional.of(SystemParticipantTestData.emInput)
     }

--- a/src/test/groovy/edu/ie3/datamodel/models/input/system/HpInputTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/input/system/HpInputTest.groovy
@@ -48,7 +48,7 @@ class HpInputTest extends Specification {
       assert qCharacteristics == hpInput.qCharacteristics
       assert thermalBus == hpInput.thermalBus
       assert type.sRated == hpInput.type.sRated * 2d
-      assert sRated == hpInput.type.sRated * 2d
+      assert sRated() == hpInput.type.sRated * 2d
       assert type.pThermal == hpInput.type.pThermal * 2d
       assert controllingEm == Optional.of(SystemParticipantTestData.emInput)
     }

--- a/src/test/groovy/edu/ie3/datamodel/models/input/system/StorageInputTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/input/system/StorageInputTest.groovy
@@ -45,7 +45,7 @@ class StorageInputTest extends Specification {
       assert id == storageInput.id
       assert qCharacteristics == storageInput.qCharacteristics
       assert type.sRated == storageInput.type.sRated * 2d
-      assert sRated == storageInput.type.sRated * 2d
+      assert sRated() == storageInput.type.sRated * 2d
       assert type.eStorage == storageInput.type.eStorage * 2d
       assert type.pMax == storageInput.type.pMax * 2d
       assert controllingEm == Optional.of(SystemParticipantTestData.emInput)

--- a/src/test/groovy/edu/ie3/datamodel/models/input/system/StorageInputTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/input/system/StorageInputTest.groovy
@@ -45,6 +45,7 @@ class StorageInputTest extends Specification {
       assert id == storageInput.id
       assert qCharacteristics == storageInput.qCharacteristics
       assert type.sRated == storageInput.type.sRated * 2d
+      assert sRated == storageInput.type.sRated * 2d
       assert type.eStorage == storageInput.type.eStorage * 2d
       assert type.pMax == storageInput.type.pMax * 2d
       assert controllingEm == Optional.of(SystemParticipantTestData.emInput)

--- a/src/test/groovy/edu/ie3/datamodel/models/input/system/WecInputTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/input/system/WecInputTest.groovy
@@ -46,7 +46,7 @@ class WecInputTest extends Specification {
       assert id == wec.id
       assert qCharacteristics == wec.qCharacteristics
       assert type.sRated == wec.type.sRated * 2d
-      assert sRated == wec.type.sRated * 2d
+      assert sRated() == wec.type.sRated * 2d
       assert type.rotorArea == wec.type.rotorArea * 2d
       assert type.hubHeight == wec.type.hubHeight
       assert marketReaction == wec.marketReaction

--- a/src/test/groovy/edu/ie3/datamodel/models/input/system/WecInputTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/input/system/WecInputTest.groovy
@@ -46,6 +46,7 @@ class WecInputTest extends Specification {
       assert id == wec.id
       assert qCharacteristics == wec.qCharacteristics
       assert type.sRated == wec.type.sRated * 2d
+      assert sRated == wec.type.sRated * 2d
       assert type.rotorArea == wec.type.rotorArea * 2d
       assert type.hubHeight == wec.type.hubHeight
       assert marketReaction == wec.marketReaction

--- a/src/test/groovy/edu/ie3/datamodel/utils/validation/InvalidSystemParticipantInput.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/utils/validation/InvalidSystemParticipantInput.groovy
@@ -8,8 +8,10 @@ package edu.ie3.datamodel.utils.validation
 import edu.ie3.datamodel.models.input.NodeInput
 import edu.ie3.datamodel.models.input.system.SystemParticipantInput
 import edu.ie3.datamodel.models.input.system.characteristic.CosPhiFixed
+import tech.units.indriya.ComparableQuantity
 
 import java.time.ZonedDateTime
+import javax.measure.quantity.Power
 
 class InvalidSystemParticipantInput extends SystemParticipantInput {
   InvalidSystemParticipantInput(NodeInput node) {
@@ -18,6 +20,11 @@ class InvalidSystemParticipantInput extends SystemParticipantInput {
 
   @Override
   boolean inOperationOn(ZonedDateTime date) {
+    throw new UnsupportedOperationException("This is a dummy class")
+  }
+
+  @Override
+  ComparableQuantity<Power> getsRated() {
     throw new UnsupportedOperationException("This is a dummy class")
   }
 

--- a/src/test/groovy/edu/ie3/datamodel/utils/validation/InvalidSystemParticipantInput.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/utils/validation/InvalidSystemParticipantInput.groovy
@@ -24,7 +24,7 @@ class InvalidSystemParticipantInput extends SystemParticipantInput {
   }
 
   @Override
-  ComparableQuantity<Power> getsRated() {
+  ComparableQuantity<Power> sRated() {
     throw new UnsupportedOperationException("This is a dummy class")
   }
 


### PR DESCRIPTION
This pull request introduces a new abstraction for file-based time series meta information and parsers, supporting both CSV and JSON formats. It refactors the handling of load profile meta information to use this new abstraction, and introduces parser interfaces and implementations for both file types. The changes improve extensibility and maintainability by unifying file handling logic and separating concerns for different file formats. Also a crucial part of implementing simonaMarkovLoad into Simona.

Key changes include:

**Abstraction and Refactoring of Load Profile Meta Information:**
- Introduced a new class `FileLoadProfileMetaInformation` to serve as a common abstraction for file-based load profile meta information, replacing the previous CSV-specific implementation. The `CsvLoadProfileMetaInformation` class now extends this new abstraction, and related code has been updated to use `FileLoadProfileMetaInformation` throughout. [[1]](diffhunk://#diff-a2721f9eb879c2d38671c5fca2a798aa253f0b33a4da922f445ce27c718fdcf9R1-R66) [[2]](diffhunk://#diff-73a0ee9ad4149e1230ef4389079c9316761c445f2ab4a0691c45be854fc8149bL2-R20) [[3]](diffhunk://#diff-42695b07776962b7f1662138be6b5cb3fe42e2d27311708b6772e9b991ad306bL12-R16) [[4]](diffhunk://#diff-42695b07776962b7f1662138be6b5cb3fe42e2d27311708b6772e9b991ad306bL121-R121) [[5]](diffhunk://#diff-42695b07776962b7f1662138be6b5cb3fe42e2d27311708b6772e9b991ad306bL140-R141) [[6]](diffhunk://#diff-0945274103284d972849baec6300d35a1ef475535d43c5844f21c0345fb1179aL11-R12) [[7]](diffhunk://#diff-0945274103284d972849baec6300d35a1ef475535d43c5844f21c0345fb1179aL161-R173) [[8]](diffhunk://#diff-0945274103284d972849baec6300d35a1ef475535d43c5844f21c0345fb1179aR184-R188)

**File Type Support and Utilities:**
- Added a new `FileType` enum to distinguish between CSV and JSON file types, including a utility method to get the file extension for each type.

**Parser Interfaces and Factory:**
- Introduced new interfaces `TimeSeriesMetaInformationParser` and `TimeSeriesMappingParser` to abstract parsing of meta information and mappings from different file types. A `FileTimeSeriesParserFactory` class was added to instantiate the appropriate parser based on file type. [[1]](diffhunk://#diff-3dc5deb9f8cfab7ca9fc283aec9c7d221d5bd922cccd8bc965035f4aca5e93daR1-R21) [[2]](diffhunk://#diff-9a653dd1ab989faf3d06f74c06cd32ac8b16ebd96d2f3f2c2779e18aff5e9b7fR1-R18) [[3]](diffhunk://#diff-3c3d3412caf7f73707f6b0ade67308e83acc56afe167dc3f928d7b8d9a48880fR1-R32)

**CSV and JSON Parser Implementations:**
- Implemented `CsvTimeSeriesMetaInformationParser` and `CsvTimeSeriesMappingParser` for CSV files, and `JsonTimeSeriesMappingParser` for JSON files, all adhering to the new parser interfaces. These implementations handle file parsing, schema validation (for JSON), and extraction of relevant meta information or mappings. [[1]](diffhunk://#diff-b1593b1c80c933ffc027c01c263999996ffd702eee4f8a0988f63989759fe963R1-R54) [[2]](diffhunk://#diff-03d0e6d50a0041e54f3f3a7857a1b8e40f857d3950c029815ed9b3c1c57918bbR1-R45) [[3]](diffhunk://#diff-c0ee329233a3b7bf0f6ed74bd58080987c047f042a5deaf4925b9043ef6743e8R1-R149)

These changes lay the groundwork for supporting additional file formats and improve the clarity and structure of time series meta information handling in the codebase.