### PR TITLE
Updated shadowJar to make it compatible with Gradle 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reintroduce `gradlew.bat` [#1531](https://github.com/ie3-institute/PowerSystemDataModel/issues/1531)
 - Remove snapshot repository [#1538](https://github.com/ie3-institute/PowerSystemDataModel/issues/1538)
 - Refactored the handling of power profiles [#1514](https://github.com/ie3-institute/PowerSystemDataModel/issues/1514)
+- Updated `gradle` dependency shadowJar to work with Gradle 9 [#1545](https://github.com/ie3-institute/PowerSystemDataModel/issues/1545)
 
 ## [8.1.0] - 2025-07-25
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
   id 'jacoco' // java code coverage plugin
   id "org.sonarqube" version "7.2.2.6593" // sonarqube
   id 'net.thauvin.erik.gradle.semver' version '1.0.4' // semantic versioning
-  id "com.github.johnrengelman.shadow" version "8.1.1" // fat jar
+  id 'com.gradleup.shadow' version '9.3.1' // fat jar
 }
 
 ext {


### PR DESCRIPTION
Closes #1545 
This pull request updates the project dependencies to ensure compatibility with Gradle 9. The most important change is an update to the `shadowJar` dependency for Gradle.

Dependency update:

* Updated the `gradle` dependency `shadowJar` to work with Gradle 9, improving build compatibility and future-proofing the project.