### PR TITLE
Preserve additional parameters in copy builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Fixed
+- Preserved additional parameters in copy builders [#1685](https://github.com/ie3-institute/PowerSystemDataModel/issues/1685)
 - Fixed issues regarding determination of additional parameters [#1661](https://github.com/ie3-institute/PowerSystemDataModel/issues/1661)
 
 ### Changed

--- a/src/main/java/edu/ie3/datamodel/models/input/AssetInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/AssetInput.java
@@ -98,7 +98,7 @@ public abstract class AssetInput extends UniqueInputEntity implements Operable {
    * @since 05.06.20
    */
   public abstract static class AssetInputCopyBuilder<B extends AssetInputCopyBuilder<B>>
-      extends UniqueEntityCopyBuilder<B> {
+      extends UniqueInputEntityCopyBuilder<B> {
 
     private String id;
     private OperatorInput operator;

--- a/src/main/java/edu/ie3/datamodel/models/input/AssetTypeInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/AssetTypeInput.java
@@ -52,7 +52,7 @@ public abstract class AssetTypeInput extends UniqueInputEntity {
    */
   public abstract static class AssetTypeInputCopyBuilder<
           B extends AssetTypeInput.AssetTypeInputCopyBuilder<B>>
-      extends UniqueEntityCopyBuilder<B> {
+      extends UniqueInputEntityCopyBuilder<B> {
 
     private String id;
 

--- a/src/main/java/edu/ie3/datamodel/models/input/EmInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/EmInput.java
@@ -158,7 +158,13 @@ public class EmInput extends AssetInput implements HasEm {
     @Override
     public EmInput build() {
       return new EmInput(
-          getUuid(), getId(), getOperator(), getOperationTime(), controlStrategy, parentEm);
+          getUuid(),
+          getId(),
+          getOperator(),
+          getOperationTime(),
+          controlStrategy,
+          parentEm,
+          getAdditionalInformation());
     }
 
     @Override

--- a/src/main/java/edu/ie3/datamodel/models/input/MeasurementUnitInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/MeasurementUnitInput.java
@@ -214,7 +214,16 @@ public class MeasurementUnitInput extends AssetInput implements HasNodes {
     @Override
     public MeasurementUnitInput build() {
       return new MeasurementUnitInput(
-          getUuid(), getId(), getOperator(), getOperationTime(), node, vMag, vAng, p, q);
+          getUuid(),
+          getId(),
+          getOperator(),
+          getOperationTime(),
+          node,
+          vMag,
+          vAng,
+          p,
+          q,
+          getAdditionalInformation());
     }
 
     public MeasurementUnitInputCopyBuilder node(NodeInput node) {

--- a/src/main/java/edu/ie3/datamodel/models/input/NodeInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/NodeInput.java
@@ -239,7 +239,8 @@ public class NodeInput extends AssetInput {
           slack,
           geoPosition,
           voltLvl,
-          subnet);
+          subnet,
+          getAdditionalInformation());
     }
 
     public NodeInputCopyBuilder vTarget(ComparableQuantity<Dimensionless> vTarget) {

--- a/src/main/java/edu/ie3/datamodel/models/input/OperatorInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/OperatorInput.java
@@ -85,7 +85,7 @@ public class OperatorInput extends UniqueInputEntity {
    * @since 05.06.20
    */
   public static class OperatorInputCopyBuilder
-      extends UniqueEntityCopyBuilder<OperatorInputCopyBuilder> {
+      extends UniqueInputEntityCopyBuilder<OperatorInputCopyBuilder> {
 
     private String id;
 
@@ -96,7 +96,7 @@ public class OperatorInput extends UniqueInputEntity {
 
     @Override
     public OperatorInput build() {
-      return new OperatorInput(getUuid(), id);
+      return new OperatorInput(getUuid(), id, getAdditionalInformation());
     }
 
     public OperatorInputCopyBuilder id(String id) {

--- a/src/main/java/edu/ie3/datamodel/models/input/UniqueInputEntity.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/UniqueInputEntity.java
@@ -33,4 +33,36 @@ public abstract class UniqueInputEntity extends UniqueEntity implements InputEnt
   public Map<String, String> getAdditionalInformation() {
     return Collections.unmodifiableMap(additionalInformation);
   }
+
+  /**
+   * Abstract class for all copy builders that build child input entities.
+   *
+   * @param <B> concrete copy builder type
+   */
+  public abstract static class UniqueInputEntityCopyBuilder<
+          B extends UniqueInputEntityCopyBuilder<B>>
+      extends UniqueEntityCopyBuilder<B> {
+
+    private Map<String, String> additionalInformation;
+
+    protected UniqueInputEntityCopyBuilder(UniqueInputEntity entity) {
+      super(entity);
+      this.additionalInformation = new HashMap<>(entity.getAdditionalInformation());
+    }
+
+    /**
+     * Replace the additional information of the copied entity.
+     *
+     * @param additionalInformation additional information for the copied entity
+     * @return this copy builder
+     */
+    public B additionalInformation(Map<String, String> additionalInformation) {
+      this.additionalInformation = new HashMap<>(additionalInformation);
+      return thisInstance();
+    }
+
+    protected Map<String, String> getAdditionalInformation() {
+      return Collections.unmodifiableMap(additionalInformation);
+    }
+  }
 }

--- a/src/main/java/edu/ie3/datamodel/models/input/connector/LineInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/connector/LineInput.java
@@ -244,7 +244,8 @@ public class LineInput extends ConnectorInput implements HasType {
           type,
           length,
           geoPosition,
-          olmCharacteristic);
+          olmCharacteristic,
+          getAdditionalInformation());
     }
 
     public LineInputCopyBuilder geoPosition(LineString geoPosition) {

--- a/src/main/java/edu/ie3/datamodel/models/input/connector/SwitchInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/connector/SwitchInput.java
@@ -147,7 +147,14 @@ public class SwitchInput extends ConnectorInput {
     @Override
     public SwitchInput build() {
       return new SwitchInput(
-          getUuid(), getId(), getOperator(), getOperationTime(), getNodeA(), getNodeB(), closed);
+          getUuid(),
+          getId(),
+          getOperator(),
+          getOperationTime(),
+          getNodeA(),
+          getNodeB(),
+          closed,
+          getAdditionalInformation());
     }
 
     public SwitchInputCopyBuilder closed(boolean closed) {

--- a/src/main/java/edu/ie3/datamodel/models/input/connector/Transformer2WInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/connector/Transformer2WInput.java
@@ -193,7 +193,8 @@ public class Transformer2WInput extends TransformerInput implements HasType {
           getParallelDevices(),
           type,
           getTapPos(),
-          isAutoTap());
+          isAutoTap(),
+          getAdditionalInformation());
     }
 
     public Transformer2WInputCopyBuilder type(Transformer2WTypeInput type) {

--- a/src/main/java/edu/ie3/datamodel/models/input/connector/Transformer3WInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/connector/Transformer3WInput.java
@@ -178,7 +178,8 @@ public class Transformer3WInput extends TransformerInput implements HasType {
             internalNodeAsSlack,
             null,
             nodeA.getVoltLvl(),
-            nodeA.getSubnet()));
+            nodeA.getSubnet()),
+        Map.of());
     connectsNodesToCorrectVoltageSides(nodeA, nodeB, nodeC);
   }
 
@@ -238,6 +239,8 @@ public class Transformer3WInput extends TransformerInput implements HasType {
    * @param type of 3W transformer
    * @param tapPos Tap Position of this transformer
    * @param autoTap true, if there is an automated regulation activated for this transformer
+   * @param internalNode The transformer's internal node
+   * @param additionalInformation Of the input
    */
   private Transformer3WInput(
       UUID uuid,
@@ -251,12 +254,14 @@ public class Transformer3WInput extends TransformerInput implements HasType {
       Transformer3WTypeInput type,
       int tapPos,
       boolean autoTap,
-      NodeInput internalNode) {
+      NodeInput internalNode,
+      Map<String, String> additionalInformation) {
     super(uuid, operationTime, operator, id, nodeA, nodeB, parallelDevices, tapPos, autoTap);
     connectsNodesToCorrectVoltageSides(nodeA, nodeB, nodeC);
     this.type = type;
     this.nodeC = nodeC;
     this.nodeInternal = internalNode;
+    setAdditionalInformation(additionalInformation);
   }
 
   @Override
@@ -382,7 +387,8 @@ public class Transformer3WInput extends TransformerInput implements HasType {
           type,
           getTapPos(),
           isAutoTap(),
-          internalNode.copy().slack(internSlack).build());
+          internalNode.copy().slack(internSlack).build(),
+          getAdditionalInformation());
     }
 
     public Transformer3WInputCopyBuilder type(Transformer3WTypeInput type) {

--- a/src/main/java/edu/ie3/datamodel/models/input/connector/type/LineTypeInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/connector/type/LineTypeInput.java
@@ -223,7 +223,8 @@ public class LineTypeInput extends AssetTypeInput {
 
     @Override
     public LineTypeInput build() {
-      return new LineTypeInput(getUuid(), getId(), b, g, r, x, iMax, vRated);
+      return new LineTypeInput(
+          getUuid(), getId(), b, g, r, x, iMax, vRated, getAdditionalInformation());
     }
 
     @Override

--- a/src/main/java/edu/ie3/datamodel/models/input/connector/type/Transformer2WTypeInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/connector/type/Transformer2WTypeInput.java
@@ -398,8 +398,22 @@ public class Transformer2WTypeInput extends AssetTypeInput {
     @Override
     public Transformer2WTypeInput build() {
       return new Transformer2WTypeInput(
-          getUuid(), getId(), rSc, xSc, sRated, vRatedA, vRatedB, gM, bM, dV, dPhi, tapSide,
-          tapNeutr, tapMin, tapMax);
+          getUuid(),
+          getId(),
+          rSc,
+          xSc,
+          sRated,
+          vRatedA,
+          vRatedB,
+          gM,
+          bM,
+          dV,
+          dPhi,
+          tapSide,
+          tapNeutr,
+          tapMin,
+          tapMax,
+          getAdditionalInformation());
     }
 
     @Override

--- a/src/main/java/edu/ie3/datamodel/models/input/connector/type/Transformer3WTypeInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/connector/type/Transformer3WTypeInput.java
@@ -543,8 +543,28 @@ public class Transformer3WTypeInput extends AssetTypeInput {
     @Override
     public Transformer3WTypeInput build() {
       return new Transformer3WTypeInput(
-          getUuid(), getId(), sRatedA, sRatedB, sRatedC, vRatedA, vRatedB, vRatedC, rScA, rScB,
-          rScC, xScA, xScB, xScC, gM, bM, dV, dPhi, tapNeutr, tapMin, tapMax);
+          getUuid(),
+          getId(),
+          sRatedA,
+          sRatedB,
+          sRatedC,
+          vRatedA,
+          vRatedB,
+          vRatedC,
+          rScA,
+          rScB,
+          rScC,
+          xScA,
+          xScB,
+          xScC,
+          gM,
+          bM,
+          dV,
+          dPhi,
+          tapNeutr,
+          tapMin,
+          tapMax,
+          getAdditionalInformation());
     }
 
     @Override

--- a/src/main/java/edu/ie3/datamodel/models/input/system/AcInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/AcInput.java
@@ -215,7 +215,8 @@ public class AcInput extends SystemParticipantInput implements HasType, HasTherm
           thermalBus,
           getqCharacteristics(),
           getEm(),
-          type);
+          type,
+          getAdditionalInformation());
     }
 
     @Override

--- a/src/main/java/edu/ie3/datamodel/models/input/system/BmInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/BmInput.java
@@ -247,7 +247,8 @@ public class BmInput extends SystemParticipantInput implements HasType {
           getEm(),
           type,
           costControlled,
-          feedInTariff);
+          feedInTariff,
+          getAdditionalInformation());
     }
 
     @Override

--- a/src/main/java/edu/ie3/datamodel/models/input/system/ChpInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/ChpInput.java
@@ -227,7 +227,8 @@ public class ChpInput extends SystemParticipantInput
           getqCharacteristics(),
           getEm(),
           type,
-          thermalStorage);
+          thermalStorage,
+          getAdditionalInformation());
     }
 
     public ChpInputCopyBuilder type(ChpTypeInput type) {

--- a/src/main/java/edu/ie3/datamodel/models/input/system/EvInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/EvInput.java
@@ -186,7 +186,8 @@ public class EvInput extends SystemParticipantInput implements HasType {
           getNode(),
           getqCharacteristics(),
           getEm(),
-          type);
+          type,
+          getAdditionalInformation());
     }
 
     @Override

--- a/src/main/java/edu/ie3/datamodel/models/input/system/EvcsInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/EvcsInput.java
@@ -352,7 +352,8 @@ public class EvcsInput extends SystemParticipantInput {
           chargingPoints,
           cosPhiRated,
           locationType,
-          v2gSupport);
+          v2gSupport,
+          getAdditionalInformation());
     }
 
     @Override

--- a/src/main/java/edu/ie3/datamodel/models/input/system/FixedFeedInInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/FixedFeedInInput.java
@@ -211,7 +211,8 @@ public class FixedFeedInInput extends SystemParticipantInput {
           getqCharacteristics(),
           getEm(),
           sRated,
-          cosPhiRated);
+          cosPhiRated,
+          getAdditionalInformation());
     }
 
     @Override

--- a/src/main/java/edu/ie3/datamodel/models/input/system/HpInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/HpInput.java
@@ -215,7 +215,8 @@ public class HpInput extends SystemParticipantInput implements HasType, HasTherm
           thermalBus,
           getqCharacteristics(),
           getEm(),
-          type);
+          type,
+          getAdditionalInformation());
     }
 
     @Override

--- a/src/main/java/edu/ie3/datamodel/models/input/system/LoadInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/LoadInput.java
@@ -357,7 +357,8 @@ public class LoadInput extends SystemParticipantInput {
           powerProfileKey,
           eConsAnnual,
           sRated,
-          cosPhiRated);
+          cosPhiRated,
+          getAdditionalInformation());
     }
 
     @Override

--- a/src/main/java/edu/ie3/datamodel/models/input/system/PvInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/PvInput.java
@@ -377,7 +377,8 @@ public class PvInput extends SystemParticipantInput {
           kG,
           kT,
           sRated,
-          cosPhiRated);
+          cosPhiRated,
+          getAdditionalInformation());
     }
 
     @Override

--- a/src/main/java/edu/ie3/datamodel/models/input/system/StorageInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/StorageInput.java
@@ -186,7 +186,8 @@ public class StorageInput extends SystemParticipantInput implements HasType {
           getNode(),
           getqCharacteristics(),
           getEm(),
-          type);
+          type,
+          getAdditionalInformation());
     }
 
     @Override

--- a/src/main/java/edu/ie3/datamodel/models/input/system/WecInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/WecInput.java
@@ -182,7 +182,8 @@ public class WecInput extends SystemParticipantInput implements HasType {
           getNode(),
           getqCharacteristics(),
           getEm(),
-          type);
+          type,
+          getAdditionalInformation());
     }
 
     public WecInputCopyBuilder type(WecTypeInput type) {

--- a/src/main/java/edu/ie3/datamodel/models/input/system/type/AcTypeInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/type/AcTypeInput.java
@@ -146,7 +146,14 @@ public class AcTypeInput extends SystemParticipantTypeInput {
     @Override
     public AcTypeInput build() {
       return new AcTypeInput(
-          getUuid(), getId(), getCapex(), getOpex(), getsRated(), getCosPhiRated(), pThermal);
+          getUuid(),
+          getId(),
+          getCapex(),
+          getOpex(),
+          getsRated(),
+          getCosPhiRated(),
+          pThermal,
+          getAdditionalInformation());
     }
 
     @Override

--- a/src/main/java/edu/ie3/datamodel/models/input/system/type/BmTypeInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/type/BmTypeInput.java
@@ -178,7 +178,8 @@ public class BmTypeInput extends SystemParticipantTypeInput {
           activePowerGradient,
           getsRated(),
           getCosPhiRated(),
-          etaConv);
+          etaConv,
+          getAdditionalInformation());
     }
 
     @Override

--- a/src/main/java/edu/ie3/datamodel/models/input/system/type/ChpTypeInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/type/ChpTypeInput.java
@@ -234,7 +234,8 @@ public class ChpTypeInput extends SystemParticipantTypeInput {
           getsRated(),
           getCosPhiRated(),
           pThermal,
-          pOwn);
+          pOwn,
+          getAdditionalInformation());
     }
 
     @Override

--- a/src/main/java/edu/ie3/datamodel/models/input/system/type/EvTypeInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/type/EvTypeInput.java
@@ -208,7 +208,8 @@ public class EvTypeInput extends SystemParticipantTypeInput {
           eCons,
           getsRated(),
           getCosPhiRated(),
-          getsRatedDC());
+          getsRatedDC(),
+          getAdditionalInformation());
     }
 
     @Override

--- a/src/main/java/edu/ie3/datamodel/models/input/system/type/HpTypeInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/type/HpTypeInput.java
@@ -144,7 +144,14 @@ public class HpTypeInput extends SystemParticipantTypeInput {
     @Override
     public HpTypeInput build() {
       return new HpTypeInput(
-          getUuid(), getId(), getCapex(), getOpex(), getsRated(), getCosPhiRated(), pThermal);
+          getUuid(),
+          getId(),
+          getCapex(),
+          getOpex(),
+          getsRated(),
+          getCosPhiRated(),
+          pThermal,
+          getAdditionalInformation());
     }
 
     @Override

--- a/src/main/java/edu/ie3/datamodel/models/input/system/type/StorageTypeInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/type/StorageTypeInput.java
@@ -269,7 +269,8 @@ public class StorageTypeInput extends SystemParticipantTypeInput {
           getCosPhiRated(),
           pMax,
           activePowerGradient,
-          eta);
+          eta,
+          getAdditionalInformation());
     }
 
     @Override

--- a/src/main/java/edu/ie3/datamodel/models/input/system/type/WecTypeInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/system/type/WecTypeInput.java
@@ -236,7 +236,8 @@ public class WecTypeInput extends SystemParticipantTypeInput {
           cpCharacteristic,
           etaConv,
           rotorArea,
-          hubHeight);
+          hubHeight,
+          getAdditionalInformation());
     }
 
     @Override

--- a/src/main/java/edu/ie3/datamodel/models/input/thermal/CylindricalStorageInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/thermal/CylindricalStorageInput.java
@@ -172,7 +172,8 @@ public class CylindricalStorageInput extends AbstractStorageInput {
           getInletTemp(),
           getReturnTemp(),
           getC(),
-          getpThermalMax());
+          getpThermalMax(),
+          getAdditionalInformation());
     }
 
     @Override

--- a/src/main/java/edu/ie3/datamodel/models/input/thermal/DomesticHotWaterStorageInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/thermal/DomesticHotWaterStorageInput.java
@@ -172,7 +172,8 @@ public class DomesticHotWaterStorageInput extends AbstractStorageInput {
           getInletTemp(),
           getReturnTemp(),
           getC(),
-          getpThermalMax());
+          getpThermalMax(),
+          getAdditionalInformation());
     }
 
     @Override

--- a/src/main/java/edu/ie3/datamodel/models/input/thermal/ThermalBusInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/thermal/ThermalBusInput.java
@@ -74,7 +74,8 @@ public class ThermalBusInput extends ThermalInput {
 
     @Override
     public ThermalBusInput build() {
-      return new ThermalBusInput(getUuid(), getId(), getOperator(), getOperationTime());
+      return new ThermalBusInput(
+          getUuid(), getId(), getOperator(), getOperationTime(), getAdditionalInformation());
     }
 
     @Override

--- a/src/main/java/edu/ie3/datamodel/models/input/thermal/ThermalHouseInput.java
+++ b/src/main/java/edu/ie3/datamodel/models/input/thermal/ThermalHouseInput.java
@@ -331,7 +331,8 @@ public class ThermalHouseInput extends ThermalSinkInput {
           upperTemperatureLimit,
           lowerTemperatureLimit,
           housingType,
-          numberInhabitants);
+          numberInhabitants,
+          getAdditionalInformation());
     }
 
     @Override

--- a/src/test/groovy/edu/ie3/datamodel/models/input/AdditionalInformationCopyBuilderTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/input/AdditionalInformationCopyBuilderTest.groovy
@@ -1,0 +1,92 @@
+/*
+ * © 2026. TU Dortmund University,
+ * Institute of Energy Systems, Energy Efficiency and Energy Economics,
+ * Research group Distribution grid planning and operation
+ */
+package edu.ie3.datamodel.models.input
+
+import edu.ie3.datamodel.io.processor.input.InputEntityProcessor
+import edu.ie3.test.common.GridTestData
+import edu.ie3.test.common.SystemParticipantTestData
+import edu.ie3.test.common.ThermalUnitInputTestData
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class AdditionalInformationCopyBuilderTest extends Specification {
+
+  @Shared
+  List<UniqueInputEntity> sources = [
+    GridTestData.profBroccoli,
+    GridTestData.energyManagementInput,
+    GridTestData.measurementUnitInput,
+    GridTestData.nodeA,
+    GridTestData.lineCtoD,
+    GridTestData.switchAtoB,
+    GridTestData.transformerBtoD,
+    GridTestData.transformerAtoBtoC,
+    GridTestData.lineTypeInputCtoD,
+    GridTestData.transformerTypeBtoD,
+    GridTestData.transformerTypeAtoBtoC,
+    SystemParticipantTestData.fixedFeedInInput,
+    SystemParticipantTestData.pvInput,
+    SystemParticipantTestData.wecInput,
+    SystemParticipantTestData.chpInput,
+    SystemParticipantTestData.bmInput,
+    SystemParticipantTestData.evInput,
+    SystemParticipantTestData.loadInput,
+    SystemParticipantTestData.storageInput,
+    SystemParticipantTestData.hpInput,
+    SystemParticipantTestData.acInput,
+    SystemParticipantTestData.evcsInput,
+    SystemParticipantTestData.wecType,
+    SystemParticipantTestData.chpTypeInput,
+    SystemParticipantTestData.bmTypeInput,
+    SystemParticipantTestData.evTypeInput,
+    SystemParticipantTestData.storageTypeInput,
+    SystemParticipantTestData.hpTypeInput,
+    SystemParticipantTestData.acTypeInput,
+    SystemParticipantTestData.thermalBus,
+    ThermalUnitInputTestData.thermalHouseInput,
+    ThermalUnitInputTestData.cylindricalStorageInput,
+    ThermalUnitInputTestData.domesticHotWaterStorageInput
+  ]
+
+  @Unroll
+  def "The #source.class.simpleName copy builder should preserve and replace additional information"() {
+    given:
+    def original = source.copy().additionalInformation([source: "legacy"]).build()
+    def replacement = [source: "updated"]
+
+    when:
+    def copied = original.copy().build()
+    def modifiedBuilder = original.copy().additionalInformation(replacement)
+    replacement.source = "changed after configuring builder"
+    def modified = modifiedBuilder.build()
+
+    then:
+    copied.additionalInformation == [source: "legacy"]
+    modified.additionalInformation == [source: "updated"]
+    original.additionalInformation == [source: "legacy"]
+
+    when:
+    modified.additionalInformation.source = "changed after build"
+
+    then:
+    thrown(UnsupportedOperationException)
+
+    where:
+    source << sources
+  }
+
+  def "The fixture matrix should cover every eligible unique input entity type"() {
+    given:
+    def coveredTypes = sources.collect { it.class } as Set
+    def eligibleTypes = InputEntityProcessor.eligibleEntityClasses.findAll {
+      UniqueInputEntity.isAssignableFrom(it)
+    } as Set
+
+    expect:
+    coveredTypes == eligibleTypes
+  }
+}

--- a/src/test/groovy/edu/ie3/datamodel/models/input/connector/Transformer3WInputTest.groovy
+++ b/src/test/groovy/edu/ie3/datamodel/models/input/connector/Transformer3WInputTest.groovy
@@ -11,6 +11,27 @@ import spock.lang.Specification
 
 class Transformer3WInputTest extends Specification {
 
+  def "A Transformer3WInput copy should preserve metadata and internal node semantics"() {
+    given:
+    def original = GridTestData.transformerAtoBtoC.copy()
+        .additionalInformation([source: "original"])
+        .build()
+    def originalSlack = original.nodeInternal.slack
+
+    when:
+    def copied = original.copy().build()
+    def changed = original.copy().internalSlack(!originalSlack).build()
+
+    then:
+    copied.additionalInformation == [source: "original"]
+    copied.nodeInternal.uuid == original.nodeInternal.uuid
+    copied.nodeInternal.slack == originalSlack
+    changed.additionalInformation == [source: "original"]
+    changed.nodeInternal.uuid == original.nodeInternal.uuid
+    changed.nodeInternal.slack == !originalSlack
+    original.nodeInternal.slack == originalSlack
+  }
+
   def "A Transformer3WInput copy method should work as expected"() {
     given:
     def trafo3w = GridTestData.transformerAtoBtoC


### PR DESCRIPTION
Resolves #1685

Copy builders currently drop additional information from copied input entities. This change preserves it across all registered copy builders and adds regression coverage for preservation, replacement, and defensive copying.

Validated with the full test suite, formatting, static analysis, coverage, and Javadocs.