### PR TITLE
fix overshadowed ParsingException in system participant factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed issues regarding determination of additional parameters [#1661](https://github.com/ie3-institute/PowerSystemDataModel/issues/1661)
+- Fixed overshadowed `ParsingException` in system participant factories [#1722](https://github.com/ie3-institute/PowerSystemDataModel/issues/1722)
 
 ### Changed
 - Switched trait `WeatherSourceTestHelper` to class and more code clean up [#1657](https://github.com/ie3-institute/PowerSystemDataModel/issues/1657)

--- a/src/main/java/edu/ie3/datamodel/io/factory/input/participant/SystemParticipantInputEntityFactory.java
+++ b/src/main/java/edu/ie3/datamodel/io/factory/input/participant/SystemParticipantInputEntityFactory.java
@@ -39,13 +39,16 @@ public abstract class SystemParticipantInputEntityFactory<
   protected T buildModel(
       D data, UUID uuid, String id, OperatorInput operator, OperationTime operationTime) {
     NodeInput node = data.getNode();
+
+    String qCharacteristicsValue = data.getField(Q_CHARACTERISTICS);
+
     ReactivePowerCharacteristic qCharacteristics;
     try {
-      qCharacteristics = ReactivePowerCharacteristic.parse(data.getField(Q_CHARACTERISTICS));
+      qCharacteristics = ReactivePowerCharacteristic.parse(qCharacteristicsValue);
     } catch (ParsingException e) {
       throw new FactoryException(
           "Cannot parse the following reactive power characteristic: '"
-              + data.getField(Q_CHARACTERISTICS)
+              + qCharacteristicsValue
               + "'",
           e);
     }

--- a/src/main/java/edu/ie3/datamodel/io/factory/typeinput/SystemParticipantTypeInputFactory.java
+++ b/src/main/java/edu/ie3/datamodel/io/factory/typeinput/SystemParticipantTypeInputFactory.java
@@ -149,10 +149,7 @@ public class SystemParticipantTypeInputFactory
       cpCharacteristic = new WecCharacteristicInput(cpCharacteristicValue);
     } catch (ParsingException e) {
       throw new FactoryException(
-          "Cannot parse the following Betz characteristic: '"
-              + cpCharacteristicValue
-              + "'",
-          e);
+          "Cannot parse the following Betz characteristic: '" + cpCharacteristicValue + "'", e);
     }
 
     return new WecTypeInput(

--- a/src/main/java/edu/ie3/datamodel/io/factory/typeinput/SystemParticipantTypeInputFactory.java
+++ b/src/main/java/edu/ie3/datamodel/io/factory/typeinput/SystemParticipantTypeInputFactory.java
@@ -142,13 +142,15 @@ public class SystemParticipantTypeInputFactory
 
     ComparableQuantity<Length> hubHeight = data.getQuantity(HUB_HEIGHT, StandardUnits.HUB_HEIGHT);
 
+    String cpCharacteristicValue = data.getField(CP_CHARACTERISTIC);
+
     WecCharacteristicInput cpCharacteristic;
     try {
-      cpCharacteristic = new WecCharacteristicInput(data.getField(CP_CHARACTERISTIC));
+      cpCharacteristic = new WecCharacteristicInput(cpCharacteristicValue);
     } catch (ParsingException e) {
       throw new FactoryException(
           "Cannot parse the following Betz characteristic: '"
-              + data.getField(CP_CHARACTERISTIC)
+              + cpCharacteristicValue
               + "'",
           e);
     }


### PR DESCRIPTION
Fixes #1722

`FactoryData.getField()` removes the entry from the field map. Calling it a
second time for the same key inside a catch block (to build the error
message) therefore failed with "Field not found", overshadowing the actual
ParsingException. Field values are now read once before the try block.